### PR TITLE
README add cargo & rustup dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ The node may run as a set of daemons (even in different docker containers);
 a multi-threaded single process or as a set of managed threads within a
 wallet app.
 
-To compile the node, please run the following commands:
+To compile the node, please install [cargo](https://doc.rust-lang.org/cargo/) and [rustup](https://rustup.rs/), then run the following commands:
 
     sudo apt update
     sudo apt install -y build-essential pkg-config libzmq3-dev libssl1.0-dev libpq-dev
+    rustup default nightly
     cargo build --release
-    
+
 Now, to run the node you can execute
 
     target/release/rgbd --data-dir ~/.rgb --bin-dir target/release -v -v -v -v


### PR DESCRIPTION
This ready for review branch updates the readme to include all the necessary dependencies to build the code.

This is mainly `cargo` [obvious for rust devs, non-trivial for users] and `rustup` needed to use the nightly rust release.