### PR TITLE
README add cmake, fix libssl-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ wallet app.
 To compile the node, please install [cargo](https://doc.rust-lang.org/cargo/) and [rustup](https://rustup.rs/), then run the following commands:
 
     sudo apt update
-    sudo apt install -y build-essential pkg-config libzmq3-dev libssl1.0-dev libpq-dev
+    sudo apt install -y build-essential pkg-config libzmq3-dev libssl-dev libpq-dev cmake
     rustup default nightly
     cargo build --release
 


### PR DESCRIPTION
This ready for review branch is a follow up for #10 [sorry for the premature PR earlier...]. It changes the README to fix two issues that I stumbled upon during building. 

1. `cmake` is needed to install `zmq-sys`
2. `libssl1.0-dev` does not work on Debian 10 https://packages.debian.org/buster/libssl-dev. But `libssl-dev` does work. I am not sure if it is alright to remove the `1.0`, so please verify that it is still working properly on other OS. Maybe, there should be a detailed building guide for different operating systems [out of scope for this PR].

With the README guide as it is in this branch, the building works properly for me. 

---

1.
```
error: failed to run custom build command for zmq-sys v0.11.0

Caused by:
  process didn't exit successfully: /home/user/rgb-node/target/release/build/zmq-sys-6c29b5158e7f654c/build-script-main (exit code: 101)
  --- stdout
  cargo:rerun-if-changed=build/main.rs
  cargo:rerun-if-env-changed=PROFILE
  running: "cmake" "/home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/zeromq-src-0.1.10+4.3.2/vendor" "-DCMAKE_INSTALL_LIBDIR=lib" "-DCMAKE_C_STANDARD=99" "-DZMQ_BUILD_TESTS=OFF" "-DENABLE_DRAFTS=OFF" "-DENABLE_CURVE=ON" "-DCMAKE_BUILD_TYPE=Release" "-DWITH_PERF_TOOL=OFF" "-DBUILD_SHARED=OFF" "-DBUILD_STATIC=ON" "-DWITH_LIBSODIUM=OFF" "-DCMAKE_INSTALL_PREFIX=/home/user/rgb-node/target/release/build/zmq-sys-f173c3c45ef0d6ee/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_ASM_COMPILER=/usr/bin/cc"

  --- stderr
  thread 'main' panicked at '
  failed to execute command: No such file or directory (os error 2)
  is cmake not installed?

  build script failed, must exit now', /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/cmake-0.1.44/src/lib.rs:885:5
  note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed
```

2.
```
$ sudo apt install -y libssl1.0-dev 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package libssl1.0-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
```

```
Compiling rand_isaac v0.1.1
error: failed to run custom build command for openssl-sys v0.9.58

Caused by:
  process didn't exit successfully: /home/user/rgb-node/target/release/build/openssl-sys-cec0e95356304672/build-script-main (exit code: 101)
  --- stdout
  cargo:rustc-cfg=const_fn
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
  OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
  OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_DIR
  OPENSSL_DIR unset
  run pkg_config fail: "\"pkg-config\" \"--libs\" \"--cflags\" \"openssl\" did not exit successfully: exit code: 1\n--- stderr\nPackage openssl was not found in the pkg-config search path.\nPerhaps you should add the directory containing `openssl.pc\'\nto the PKG_CONFIG_PATH environment variable\nNo package \'openssl\' found\n"

  --- stderr
  thread 'main' panicked at '

  Could not find directory of OpenSSL installation, and this -sys crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the OPENSSL_DIR environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, libssl-dev on Ubuntu or openssl-devel on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/sfackler/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-unknown-linux-gnu
  $TARGET = x86_64-unknown-linux-gnu
  openssl-sys = 0.9.58

  ', /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.58/build/find_normal.rs:157:5
  note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed
```

---

Please note that I have an edge-case setup with Qubes 4, there might be some issues with the template VM [where software is installed] / App VM [where software is executed] architecture, and that my fix breaks the setup of other OS. So again, please review :grinning: