### PR TITLE
RGB: Fungible assets update: burn, replacement, renomination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,7 +855,7 @@ checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 [[package]]
 name = "lnpbp"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/LNP-BP/rust-lnpbp?tag=v0.1.0-rc.1#55519daba8f2aa6311688dd4d7032c265589124e"
+source = "git+https://github.com/LNP-BP/rust-lnpbp?branch=master#cdded3238e010af5d2c0ffbeefe7d41d2a7a71df"
 dependencies = [
  "amplify",
  "amplify_derive",
@@ -883,7 +883,7 @@ dependencies = [
 [[package]]
 name = "lnpbp_derive"
 version = "0.1.0-rc.1"
-source = "git+https://github.com/LNP-BP/rust-lnpbp?tag=v0.1.0-rc.1#55519daba8f2aa6311688dd4d7032c265589124e"
+source = "git+https://github.com/LNP-BP/rust-lnpbp?branch=master#cdded3238e010af5d2c0ffbeefe7d41d2a7a71df"
 dependencies = [
  "amplify",
  "quote 1.0.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "57f080656cc1eb3d55c2446813e6197293f5d43b4cf52ffb1f6cb5ca18e0ac0b"
 dependencies = [
  "amplify",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -96,7 +96,7 @@ checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_json",
- "syn 1.0.42",
+ "syn 1.0.43",
  "tempfile",
  "toml 0.5.6",
 ]
@@ -322,7 +322,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -393,7 +393,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "strsim 0.9.3",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -404,7 +404,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -625,7 +625,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -887,7 +887,7 @@ source = "git+https://github.com/LNP-BP/rust-lnpbp?tag=v0.1.0-rc.1#55519daba8f2a
 dependencies = [
  "amplify",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -1020,7 +1020,7 @@ checksum = "6f09b9841adb6b5e1f89ef7087ea636e0fd94b2851f887c1e3eb5d5f8228fab3"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -1148,7 +1148,7 @@ checksum = "c82fb1329f632c3552cf352d14427d57a511b1cf41db93b3a7d77906a82dcc8e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -1184,7 +1184,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
  "version_check",
 ]
 
@@ -1634,7 +1634,7 @@ checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -1667,7 +1667,7 @@ dependencies = [
  "darling",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "1e2e59c50ed8f6b050b071aa7b6865293957a9af6b58b94f97c1c9434ad440ea"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -1850,7 +1850,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
  "unicode-xid 0.2.1",
 ]
 
@@ -1912,7 +1912,7 @@ checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -1986,7 +1986,7 @@ checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
 ]
 
 [[package]]
@@ -2142,7 +2142,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
  "wasm-bindgen-shared",
 ]
 
@@ -2164,7 +2164,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2304,7 +2304,7 @@ checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.42",
+ "syn 1.0.43",
  "synstructure 0.12.4",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,12 +40,12 @@ electrum-client = "=0.3.0-beta.1"
 
 [dependencies.lnpbp]
 git = "https://github.com/LNP-BP/rust-lnpbp"
-tag = "v0.1.0-rc.1"
+branch = "master"
 features = ["all"]
 
 [dependencies.lnpbp_derive]
 git = "https://github.com/LNP-BP/rust-lnpbp"
-tag = "v0.1.0-rc.1"
+branch = "master"
 
 [target.'cfg(target_os="android")'.dependencies.zmq]
 version = "~0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,5 @@ bitcoin = { git = "https://github.com/LNP-BP/rust-bitcoin", tag = "lnpbp-v0.1.0-
 # We need custom branches here just to depend on the same bitcoin master and do
 # not have secp256k1 version conflict
 miniscript = { git = "https://github.com/LNP-BP/rust-miniscript", tag = "lnpbp-v0.1.0-rc1" }
-# Remove this once https://github.com/teawithsand/torut/pull/5 got merged
 # Remove this once https://github.com/jean-airoldie/zeromq-src-rs/pull/15 got merged
 zeromq-src = { git = "https://github.com/LNP-BP/zeromq-src-rs", branch = "fix/cmake" }

--- a/ffi/ios/DemoApp/RGB Demo App.xcodeproj/project.pbxproj
+++ b/ffi/ios/DemoApp/RGB Demo App.xcodeproj/project.pbxproj
@@ -348,6 +348,7 @@
 				CODE_SIGN_ENTITLEMENTS = "RGB Demo App/RGB Demo App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = BLS4N8A6L6;
+				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "RGB Demo App/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -377,6 +378,7 @@
 				CODE_SIGN_ENTITLEMENTS = "RGB Demo App/RGB Demo App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = BLS4N8A6L6;
+				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "RGB Demo App/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -14,7 +14,6 @@ use rgb::lnpbp::bitcoin::OutPoint;
 
 use rgb::lnpbp::bp;
 use rgb::lnpbp::lnp::transport::zmq::{SocketLocator, UrlError};
-use rgb::lnpbp::rgb::Amount;
 
 use rgb::fungible::{Invoice, IssueStructure, Outcoins};
 use rgb::i9n::*;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -188,8 +188,6 @@ struct IssueArgs {
     precision: u8,
     #[serde(default)]
     prune_seals: Vec<SealSpec>,
-    #[serde(default)]
-    dust_limit: Option<Amount>,
 }
 
 fn _issue(runtime: &COpaqueStruct, json: *mut c_char) -> Result<(), String> {
@@ -208,7 +206,6 @@ fn _issue(runtime: &COpaqueStruct, json: *mut c_char) -> Result<(), String> {
             data.allocations,
             data.precision,
             data.prune_seals,
-            data.dust_limit,
         )
         .map_err(|e| format!("{:?}", e))
 }

--- a/src/api/fungible.rs
+++ b/src/api/fungible.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use lnpbp::bitcoin::util::psbt::PartiallySignedTransaction;
 use lnpbp::bitcoin::OutPoint;
 use lnpbp::bp::blind::OutpointReveal;
-use lnpbp::rgb::{Amount, Consignment, ContractId};
+use lnpbp::rgb::{Consignment, ContractId};
 
 use crate::fungible::{Outcoincealed, Outcoins};
 use crate::util::SealSpec;
@@ -80,10 +80,6 @@ pub struct Issue {
     /// Precision, i.e. number of digits reserved for fractional part
     #[clap(short, long, default_value = "0")]
     pub precision: u8,
-
-    /// Dust limit for asset transfers; defaults to no limit
-    #[clap(short = 'D', long)]
-    pub dust_limit: Option<Amount>,
 
     /// Asset allocation, in form of <amount>@<txid>:<vout>
     #[clap(required = true)]

--- a/src/contracts/fungible/data/asset.rs
+++ b/src/contracts/fungible/data/asset.rs
@@ -181,9 +181,9 @@ impl TryFrom<Genesis> for Asset {
             Err(SchemaError::WrongSchemaId)?;
         }
         let genesis_meta = genesis.metadata();
-        let fractional_bits = genesis_meta.u8(-FieldType::Precision)?;
+        let fractional_bits = genesis_meta.u8(*FieldType::Precision)?;
         let supply = Coins::with_sats_precision(
-            genesis_meta.u64(-FieldType::IssuedSupply)?,
+            genesis_meta.u64(*FieldType::IssuedSupply)?,
             fractional_bits,
         );
 
@@ -191,13 +191,13 @@ impl TryFrom<Genesis> for Asset {
         let issue = Issue {
             id: genesis.contract_id(),
             txo: genesis
-                .known_seal_definitions_by_type(-OwnedRightsType::Issue)
+                .known_seal_definitions_by_type(*OwnedRightsType::Issue)
                 .first()
                 .and_then(|i| bitcoin::OutPoint::try_from((*i).clone()).ok()),
             supply: supply.clone(),
         };
         let mut known_allocations = BTreeMap::<bitcoin::OutPoint, Vec<Allocation>>::default();
-        for variant in genesis.owned_rights_by_type(-OwnedRightsType::Assets) {
+        for variant in genesis.owned_rights_by_type(*OwnedRightsType::Assets) {
             if let Assignments::DiscreteFiniteField(tree) = variant {
                 tree.iter().enumerate().for_each(|(index, assign)| {
                     if let OwnedState::Revealed {
@@ -220,22 +220,22 @@ impl TryFrom<Genesis> for Asset {
         Ok(Self {
             id: genesis.contract_id(),
             chain: genesis.chain().clone(),
-            ticker: genesis_meta.string(-FieldType::Ticker)?,
-            name: genesis_meta.string(-FieldType::Name)?,
-            description: genesis_meta.string(-FieldType::Description).next(),
+            ticker: genesis_meta.string(*FieldType::Ticker)?,
+            name: genesis_meta.string(*FieldType::Name)?,
+            description: genesis_meta.string(*FieldType::Description).next(),
             supply: Supply {
                 known_circulating: supply.clone(),
                 total: Some(Coins::with_sats_precision(
-                    genesis_meta.u64(-FieldType::TotalSupply)?,
+                    genesis_meta.u64(*FieldType::TotalSupply)?,
                     fractional_bits,
                 )),
             },
             dust_limit: Coins::with_sats_precision(
-                genesis_meta.u64(-FieldType::DustLimit)?,
+                genesis_meta.u64(*FieldType::DustLimit)?,
                 fractional_bits,
             ),
             fractional_bits,
-            date: NaiveDateTime::from_timestamp(genesis_meta.i64(-FieldType::Timestamp)?, 0),
+            date: NaiveDateTime::from_timestamp(genesis_meta.i64(*FieldType::Timestamp)?, 0),
             unspent_issue_txo: None,
             known_issues: vec![list! { issue }],
             // we assume that each genesis allocation with revealed amount

--- a/src/contracts/fungible/data/asset.rs
+++ b/src/contracts/fungible/data/asset.rs
@@ -85,7 +85,6 @@ pub struct Asset {
     name: String,
     description: Option<String>,
     supply: Supply,
-    dust_limit: Coins,
     #[serde(with = "serde_with::rust::display_fromstr")]
     chain: bp::Chain,
     fractional_bits: u8,
@@ -230,10 +229,6 @@ impl TryFrom<Genesis> for Asset {
                     fractional_bits,
                 )),
             },
-            dust_limit: Coins::with_sats_precision(
-                genesis_meta.u64(*FieldType::DustLimit)?,
-                fractional_bits,
-            ),
             fractional_bits,
             date: NaiveDateTime::from_timestamp(genesis_meta.i64(*FieldType::Timestamp)?, 0),
             unspent_issue_txo: None,

--- a/src/contracts/fungible/data/schema.rs
+++ b/src/contracts/fungible/data/schema.rs
@@ -142,16 +142,17 @@ pub fn schema() -> Schema {
             FieldType::Ticker => DataFormat::String(8),
             FieldType::Name => DataFormat::String(256),
             // Description may contain URL, text or text representation of
-            // Ricardian contract. We use all available size, in case the
-            // contract is long. If the contract still doesn't fit, a hash or
-            // URL should be used instead, pointing to the full contract text
+            // Ricardian contract, up to 64kb. If the contract doesn't fit, a
+            // double SHA256 hash and URL should be used instead, pointing to
+            // the full contract text, where hash must be represented by a
+            // hexadecimal string, optionally followed by `\n` and text URL
             FieldType::Description => DataFormat::String(core::u16::MAX),
             FieldType::TotalSupply => DataFormat::Unsigned(Bits::Bit64, 0, core::u64::MAX as u128),
             FieldType::Precision => DataFormat::Unsigned(Bits::Bit8, 0, 18u128),
             FieldType::IssuedSupply => DataFormat::Unsigned(Bits::Bit64, 0, core::u64::MAX as u128),
-            // While UNIX timestamps allow negative numbers; in context of RGB Schema, assets
-            // can't be issued in the past before RGB or Bitcoin even existed; so we prohibit
-            // all the dates before RGB release
+            // While UNIX timestamps allow negative numbers; in context of RGB
+            // Schema, assets can't be issued in the past before RGB or Bitcoin
+            // even existed; so we prohibit all the dates before RGB release
             // TODO: Update lower allowed timestamp value with the first RGB release
             //       Current lower time limit is 07/04/2020 @ 1:54pm (UTC)
             FieldType::Timestamp => DataFormat::Integer(Bits::Bit64, 1593870844, core::i64::MAX as i128),

--- a/src/contracts/fungible/data/schema.rs
+++ b/src/contracts/fungible/data/schema.rs
@@ -49,13 +49,12 @@ pub enum FieldType {
     Ticker = 0,
     Name = 1,
     Description = 2,
-    TotalSupply = 3,
-    IssuedSupply = 4,
-    DustLimit = 5,
-    Precision = 6,
-    Timestamp = 7,
-    HistoryProof = 8,
-    HistoryProofFormat = 9,
+    Precision = 3,
+    TotalSupply = 4,
+    IssuedSupply = 5,
+    Timestamp = 6,
+    HistoryProof = 7,
+    HistoryProofFormat = 8,
 }
 
 #[derive(
@@ -199,7 +198,6 @@ pub fn schema() -> Schema {
                 FieldType::Description => Occurences::NoneOrOnce,
                 FieldType::TotalSupply => Occurences::Once,
                 FieldType::IssuedSupply => Occurences::Once,
-                FieldType::DustLimit => Occurences::NoneOrOnce,
                 FieldType::Precision => Occurences::Once,
                 FieldType::Timestamp => Occurences::Once
             },

--- a/src/contracts/fungible/data/schema.rs
+++ b/src/contracts/fungible/data/schema.rs
@@ -48,7 +48,10 @@ pub enum FieldType {
     Precision,
     TotalSupply,
     IssuedSupply,
+    ReplacedSupply,
+    BurnedSupply,
     Timestamp,
+    BurnedUtxo,
     HistoryProof,
     HistoryProofFormat,
 }
@@ -140,6 +143,8 @@ pub fn schema() -> Schema {
             FieldType::TotalSupply => DataFormat::Unsigned(Bits::Bit64, 0, core::u64::MAX as u128),
             FieldType::Precision => DataFormat::Unsigned(Bits::Bit8, 0, 18u128),
             FieldType::IssuedSupply => DataFormat::Unsigned(Bits::Bit64, 0, core::u64::MAX as u128),
+            FieldType::ReplacedSupply => DataFormat::Unsigned(Bits::Bit64, 0, core::u64::MAX as u128),
+            FieldType::BurnedSupply => DataFormat::Unsigned(Bits::Bit64, 0, core::u64::MAX as u128),
             // While UNIX timestamps allow negative numbers; in context of RGB
             // Schema, assets can't be issued in the past before RGB or Bitcoin
             // even existed; so we prohibit all the dates before RGB release
@@ -147,7 +152,8 @@ pub fn schema() -> Schema {
             //       Current lower time limit is 07/04/2020 @ 1:54pm (UTC)
             FieldType::Timestamp => DataFormat::Integer(Bits::Bit64, 1593870844, core::i64::MAX as i128),
             FieldType::HistoryProof => DataFormat::Bytes(core::u16::MAX),
-            FieldType::HistoryProofFormat => DataFormat::Enum(HistoryProofFormat::all())
+            FieldType::HistoryProofFormat => DataFormat::Enum(HistoryProofFormat::all()),
+            FieldType::BurnedUtxo => DataFormat::TxOutPoint
         },
         owned_right_types: type_map! {
             OwnedRightsType::Issue => StateSchema {
@@ -238,6 +244,7 @@ pub fn schema() -> Schema {
             TransitionType::Replacement => TransitionSchema {
                 metadata: type_map! {
                     FieldType::IssuedSupply => Occurences::Once,
+                    FieldType::BurnedUtxo => Occurences::OnceOrUpTo(None),
                     FieldType::HistoryProofFormat => Occurences::Once,
                     FieldType::HistoryProof => Occurences::NoneOrUpTo(None)
                 },
@@ -284,9 +291,12 @@ impl Deref for FieldType {
             FieldType::Precision => &3,
             FieldType::TotalSupply => &4,
             FieldType::IssuedSupply => &5,
-            FieldType::Timestamp => &6,
-            FieldType::HistoryProof => &7,
-            FieldType::HistoryProofFormat => &8,
+            FieldType::ReplacedSupply => &6,
+            FieldType::BurnedSupply => &7,
+            FieldType::BurnedUtxo => &8,
+            FieldType::Timestamp => &9,
+            FieldType::HistoryProof => &10,
+            FieldType::HistoryProofFormat => &11,
         }
     }
 }

--- a/src/contracts/fungible/data/schema.rs
+++ b/src/contracts/fungible/data/schema.rs
@@ -151,9 +151,8 @@ pub fn schema() -> Schema {
             // While UNIX timestamps allow negative numbers; in context of RGB
             // Schema, assets can't be issued in the past before RGB or Bitcoin
             // even existed; so we prohibit all the dates before RGB release
-            // TODO: Update lower allowed timestamp value with the first RGB release
-            //       Current lower time limit is 07/04/2020 @ 1:54pm (UTC)
-            FieldType::Timestamp => DataFormat::Integer(Bits::Bit64, 1593870844, core::i64::MAX as i128),
+            // This timestamp is equal to 10/10/2020 @ 2:37pm (UTC)
+            FieldType::Timestamp => DataFormat::Integer(Bits::Bit64, 1602340666, core::i64::MAX as i128),
             FieldType::HistoryProof => DataFormat::Bytes(core::u16::MAX),
             FieldType::HistoryProofFormat => DataFormat::Enum(HistoryProofFormat::all()),
             FieldType::BurnedUtxo => DataFormat::TxOutPoint

--- a/src/contracts/fungible/data/schema.rs
+++ b/src/contracts/fungible/data/schema.rs
@@ -11,7 +11,7 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-use core::ops::{Deref, Neg};
+use core::ops::Deref;
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::ToPrimitive;
 use std::collections::BTreeSet;
@@ -105,14 +105,6 @@ pub enum HistoryProofFormat {
     ProovV13 = 0xD,
     ProovV14 = 0xE,
     ProovV15 = 0xF,
-}
-
-impl Deref for HistoryProofFormat {
-    type Target = u8;
-
-    fn deref(&self) -> &Self::Target {
-        &self.to_u8().expect("History proofs always fit into u8")
-    }
 }
 
 impl HistoryProofFormat {
@@ -271,26 +263,34 @@ pub fn schema() -> Schema {
     }
 }
 
-impl Neg for FieldType {
-    type Output = usize;
+impl Deref for FieldType {
+    type Target = usize;
 
-    fn neg(self) -> Self::Output {
-        self.to_usize().unwrap()
+    fn deref(&self) -> &Self::Target {
+        &self.to_usize().expect("Any enum always fits into usize")
     }
 }
 
-impl Neg for OwnedRightsType {
-    type Output = usize;
+impl Deref for OwnedRightsType {
+    type Target = usize;
 
-    fn neg(self) -> Self::Output {
-        self.to_usize().unwrap()
+    fn deref(&self) -> &Self::Target {
+        &self.to_usize().expect("Any enum always fits into usize")
     }
 }
 
-impl Neg for TransitionType {
-    type Output = usize;
+impl Deref for TransitionType {
+    type Target = usize;
 
-    fn neg(self) -> Self::Output {
-        self.to_usize().unwrap()
+    fn deref(&self) -> &Self::Target {
+        &self.to_usize().expect("Any enum always fits into usize")
+    }
+}
+
+impl Deref for HistoryProofFormat {
+    type Target = u8;
+
+    fn deref(&self) -> &Self::Target {
+        &self.to_u8().expect("History proofs always fit into u8")
     }
 }

--- a/src/contracts/fungible/data/schema.rs
+++ b/src/contracts/fungible/data/schema.rs
@@ -173,9 +173,7 @@ pub fn schema() -> Schema {
             },
             OwnedRightsType::Epoch => StateSchema {
                 format: StateFormat::Declarative,
-                abi: bmap! {
-                    AssignmentAction::Validate => script::Procedure::NoOp
-                }
+                abi: bmap! {}
             },
             OwnedRightsType::Replacement => StateSchema {
                 format: StateFormat::Declarative,
@@ -185,12 +183,10 @@ pub fn schema() -> Schema {
             },
             OwnedRightsType::Renomination => StateSchema {
                 format: StateFormat::Declarative,
-                abi: bmap! {
-                    AssignmentAction::Validate => script::Procedure::NoOp
-                }
+                abi: bmap! {}
             }
         },
-        public_right_types: Default::default(),
+        public_right_types: bset![],
         genesis: GenesisSchema {
             metadata: type_map! {
                 FieldType::Ticker => Occurences::Once,
@@ -207,10 +203,10 @@ pub fn schema() -> Schema {
                 OwnedRightsType::Assets => Occurences::NoneOrUpTo(None),
                 OwnedRightsType::Renomination => Occurences::NoneOrOnce
             },
-            public_rights: Default::default(),
+            public_rights: bset![],
             abi: bmap! {},
         },
-        extensions: Default::default(),
+        extensions: bmap![],
         transitions: type_map! {
             TransitionType::Issue => TransitionSchema {
                 metadata: type_map! {
@@ -224,7 +220,7 @@ pub fn schema() -> Schema {
                     OwnedRightsType::Epoch => Occurences::NoneOrOnce,
                     OwnedRightsType::Assets => Occurences::NoneOrUpTo(None)
                 },
-                public_rights: Default::default(),
+                public_rights: bset! [],
                 abi: bmap! {}
             },
             TransitionType::Transfer => TransitionSchema {
@@ -235,7 +231,7 @@ pub fn schema() -> Schema {
                 owned_rights: type_map! {
                     OwnedRightsType::Assets => Occurences::NoneOrUpTo(None)
                 },
-                public_rights: Default::default(),
+                public_rights: bset! [],
                 abi: bmap! {}
             },
             TransitionType::Epoch => TransitionSchema {
@@ -247,7 +243,7 @@ pub fn schema() -> Schema {
                     OwnedRightsType::Epoch => Occurences::NoneOrOnce,
                     OwnedRightsType::Replacement => Occurences::NoneOrOnce
                 },
-                public_rights: Default::default(),
+                public_rights: bset! [],
                 abi: bmap! {}
             },
             TransitionType::Replacement => TransitionSchema {
@@ -263,7 +259,7 @@ pub fn schema() -> Schema {
                     OwnedRightsType::Replacement => Occurences::NoneOrOnce,
                     OwnedRightsType::Assets => Occurences::OnceOrUpTo(None)
                 },
-                public_rights: Default::default(),
+                public_rights: bset! [],
                 abi: bmap! {}
             },
             TransitionType::Renomination => TransitionSchema {
@@ -279,7 +275,7 @@ pub fn schema() -> Schema {
                 owned_rights: type_map! {
                     OwnedRightsType::Renomination => Occurences::NoneOrOnce
                 },
-                public_rights: Default::default(),
+                public_rights: bset! [],
                 abi: bmap! {}
             }
         },

--- a/src/contracts/fungible/data/schema.rs
+++ b/src/contracts/fungible/data/schema.rs
@@ -68,6 +68,7 @@ pub enum OwnedRightsType {
     Assets = 1,
     Epoch = 2,
     Replacement = 3,
+    Renomination = 4,
 }
 
 #[derive(
@@ -80,6 +81,7 @@ pub enum TransitionType {
     Transfer = 1,
     Epoch = 2,
     Replacement = 3,
+    Renomination = 4,
 }
 
 #[derive(
@@ -181,6 +183,12 @@ pub fn schema() -> Schema {
                 abi: bmap! {
                     AssignmentAction::Validate => script::Procedure::Standard(script::StandardProcedure::Replacement)
                 }
+            },
+            OwnedRightsType::Renomination => StateSchema {
+                format: StateFormat::Declarative,
+                abi: bmap! {
+                    AssignmentAction::Validate => script::Procedure::NoOp
+                }
             }
         },
         public_right_types: Default::default(),
@@ -198,7 +206,8 @@ pub fn schema() -> Schema {
             owned_rights: type_map! {
                 OwnedRightsType::Issue => Occurences::NoneOrOnce,
                 OwnedRightsType::Epoch => Occurences::NoneOrOnce,
-                OwnedRightsType::Assets => Occurences::NoneOrUpTo(None)
+                OwnedRightsType::Assets => Occurences::NoneOrUpTo(None),
+                OwnedRightsType::Renomination => Occurences::NoneOrOnce
             },
             public_rights: Default::default(),
             abi: bmap! {},
@@ -255,6 +264,22 @@ pub fn schema() -> Schema {
                 owned_rights: type_map! {
                     OwnedRightsType::Replacement => Occurences::NoneOrOnce,
                     OwnedRightsType::Assets => Occurences::OnceOrUpTo(None)
+                },
+                public_rights: Default::default(),
+                abi: bmap! {}
+            },
+            TransitionType::Renomination => TransitionSchema {
+                metadata: type_map! {
+                    FieldType::Ticker => Occurences::NoneOrOnce,
+                    FieldType::Name => Occurences::NoneOrOnce,
+                    FieldType::Description => Occurences::NoneOrOnce,
+                    FieldType::Precision => Occurences::NoneOrOnce
+                },
+                closes: type_map! {
+                    OwnedRightsType::Renomination => Occurences::Once
+                },
+                owned_rights: type_map! {
+                    OwnedRightsType::Renomination => Occurences::NoneOrOnce
                 },
                 public_rights: Default::default(),
                 abi: bmap! {}

--- a/src/contracts/fungible/processor.rs
+++ b/src/contracts/fungible/processor.rs
@@ -71,14 +71,12 @@ impl Processor {
         allocations: Vec<Outcoins>,
         precision: u8,
         prune_seals: Vec<SealSpec>,
-        dust_limit: Option<Amount>,
     ) -> Result<(Asset, Genesis), ServiceErrorDomain> {
         let now = Utc::now().timestamp();
         let mut metadata = type_map! {
             FieldType::Ticker => field!(String, ticker),
             FieldType::Name => field!(String, name),
             FieldType::Precision => field!(U8, precision),
-            FieldType::DustLimit => field!(U64, dust_limit.unwrap_or(0)),
             FieldType::Timestamp => field!(I64, now)
         };
         if let Some(description) = description {

--- a/src/contracts/fungible/processor.rs
+++ b/src/contracts/fungible/processor.rs
@@ -127,7 +127,7 @@ impl Processor {
         }
 
         owned_rights.insert(
-            -OwnedRightsType::Prune,
+            -OwnedRightsType::Replacement,
             Assignments::Declarative(
                 prune_seals
                     .into_iter()

--- a/src/contracts/fungible/processor.rs
+++ b/src/contracts/fungible/processor.rs
@@ -125,7 +125,7 @@ impl Processor {
         }
 
         owned_rights.insert(
-            *OwnedRightsType::Replacement,
+            *OwnedRightsType::BurnReplace,
             Assignments::Declarative(
                 prune_seals
                     .into_iter()

--- a/src/contracts/fungible/processor.rs
+++ b/src/contracts/fungible/processor.rs
@@ -82,7 +82,7 @@ impl Processor {
             FieldType::Timestamp => field!(I64, now)
         };
         if let Some(description) = description {
-            metadata.insert(-FieldType::Description, field!(String, description));
+            metadata.insert(*FieldType::Description, field!(String, description));
         }
 
         let mut issued_supply = 0u64;
@@ -96,10 +96,10 @@ impl Processor {
             .collect();
         let mut owned_rights = BTreeMap::new();
         owned_rights.insert(
-            -OwnedRightsType::Assets,
+            *OwnedRightsType::Assets,
             Assignments::zero_balanced(vec![], allocations, vec![]),
         );
-        metadata.insert(-FieldType::IssuedSupply, field!(U64, issued_supply));
+        metadata.insert(*FieldType::IssuedSupply, field!(U64, issued_supply));
 
         let mut total_supply = issued_supply;
         if let IssueStructure::MultipleIssues {
@@ -114,20 +114,20 @@ impl Processor {
                     total_supply, issued_supply
                 )))?;
             }
-            metadata.insert(-FieldType::TotalSupply, field!(U64, total_supply));
+            metadata.insert(*FieldType::TotalSupply, field!(U64, total_supply));
             owned_rights.insert(
-                -OwnedRightsType::Issue,
+                *OwnedRightsType::Issue,
                 Assignments::Declarative(bset![OwnedState::Revealed {
                     seal_definition: reissue_control.seal_definition(),
                     assigned_state: data::Void
                 }]),
             );
         } else {
-            metadata.insert(-FieldType::TotalSupply, field!(U64, total_supply));
+            metadata.insert(*FieldType::TotalSupply, field!(U64, total_supply));
         }
 
         owned_rights.insert(
-            -OwnedRightsType::Replacement,
+            *OwnedRightsType::Replacement,
             Assignments::Declarative(
                 prune_seals
                     .into_iter()
@@ -217,13 +217,13 @@ impl Processor {
             parent
                 .entry(alloc.node_id)
                 .or_insert(bmap! {})
-                .entry(-OwnedRightsType::Assets)
+                .entry(*OwnedRightsType::Assets)
                 .or_insert(vec![])
                 .push(alloc.index);
         }
 
         let transition = Transition::with(
-            -TransitionType::Transfer,
+            *TransitionType::Transfer,
             metadata.into(),
             parent,
             assignments,

--- a/src/contracts/fungible/runtime.rs
+++ b/src/contracts/fungible/runtime.rs
@@ -372,7 +372,7 @@ impl Runtime {
             };
 
             for (_, transition) in &accept.consignment.state_transitions {
-                let set = transition.owned_rights_by_type(-OwnedRightsType::Assets);
+                let set = transition.owned_rights_by_type(*OwnedRightsType::Assets);
                 for variant in set {
                     if let Assignments::DiscreteFiniteField(set) = variant {
                         for (index, assignment) in set.into_iter().enumerate() {

--- a/src/contracts/fungible/runtime.rs
+++ b/src/contracts/fungible/runtime.rs
@@ -215,7 +215,6 @@ impl Runtime {
             issue.allocate.clone(),
             issue.precision,
             vec![],
-            issue.dust_limit,
         )?;
 
         self.import_asset(asset, genesis).await?;

--- a/src/i9n/fungible.rs
+++ b/src/i9n/fungible.rs
@@ -22,7 +22,6 @@ use lnpbp::bitcoin::OutPoint;
 use lnpbp::bp;
 use lnpbp::lnp::presentation::Encode;
 use lnpbp::lnp::Unmarshall;
-use lnpbp::rgb::Amount;
 
 use super::{Error, Runtime};
 use crate::api::{fungible::Issue, fungible::Request, fungible::TransferApi, reply, Reply};
@@ -50,7 +49,6 @@ impl Runtime {
         allocate: Vec<Outcoins>,
         precision: u8,
         _prune_seals: Vec<SealSpec>,
-        dust_limit: Option<Amount>,
     ) -> Result<(), Error> {
         // TODO: Make sure we use the same network
         let (supply, inflatable) = match issue_structure {
@@ -67,7 +65,6 @@ impl Runtime {
             supply,
             inflatable,
             precision,
-            dust_limit,
             allocate,
         });
         match &*self.command(command)? {

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -21,9 +21,10 @@ macro_rules! type_map {
 
     { $($key:expr => $value:expr),+ } => {
         {
+            use num_traits::ToPrimitive;
             let mut m = ::std::collections::BTreeMap::new();
             $(
-                m.insert(-$key, $value);
+                m.insert($key.to_usize().unwrap(), $value);
             )+
             m
         }

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -21,10 +21,9 @@ macro_rules! type_map {
 
     { $($key:expr => $value:expr),+ } => {
         {
-            use num_traits::ToPrimitive;
             let mut m = ::std::collections::BTreeMap::new();
             $(
-                m.insert($key.to_usize().unwrap(), $value);
+                m.insert(*$key, $value);
             )+
             m
         }


### PR DESCRIPTION
Proposal to https://github.com/LNP-BP/LNPBPs/issues/38

Burn & reissue procedure named "replacement" and organized as a linear sequence within a linear sequence of epochs. Each epoch can replace maximum 100% of its original issue/supply (created at genesis or with a secondary issue ancestor).

Each issue (primary in genesis and secondary with `issue` state transition type) defines up to a single `epoch` seal.

When the seal is closed, a `Epoch` state transition must be created, which 
1) MUST has no metadata;
2) MAY define a single next `epoch` seal (otherwise it will mean that no further replacement epochs are allowed), and
3) MUST define a single `replacement` seal.

Replacement seals are closed with `Replacement` state transition type, which
1) MAY optionally provide some binary proof data (with empty data validated as valid and the rest of data are validated as invalid until some possible future standard update);
2) specifies an amount to be reissued/replaced;
3) MUST define up to a single `replacement` seal.

Replacement state has a special validation procedure, which fails if the sum of all replacements within the epoch exceeds the original issued amount.

Upd: Use replacement workflow for asset recovery: https://github.com/LNP-BP/LNPBPs/issues/50
