### PR TITLE
RGB: identity schema proposal

### DIFF
--- a/src/contracts/identity/data/schema.rs
+++ b/src/contracts/identity/data/schema.rs
@@ -1,0 +1,146 @@
+// RGB standard library
+// Written in 2020 by
+//     Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the MIT License
+// along with this software.
+// If not, see <https://opensource.org/licenses/MIT>.
+
+use core::ops::Neg;
+use num_derive::{FromPrimitive, ToPrimitive};
+use num_traits::ToPrimitive;
+
+use lnpbp::rgb::schema::{
+    script, AssignmentAction, Bits, DataFormat, DiscreteFiniteFieldFormat, GenesisSchema,
+    Occurences, Schema, StateFormat, StateSchema, TransitionSchema,
+};
+
+use crate::type_map;
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Display, ToPrimitive, FromPrimitive)]
+#[display_from(Debug)]
+#[repr(u16)]
+pub enum FieldType {
+    Name = 0,
+    Format = 1,
+    Identity = 2,
+    Cryptography = 3,
+    PublicKey = 4,
+    Signature = 5,
+    ValidFrom = 6,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Display, ToPrimitive, FromPrimitive)]
+#[display_from(Debug)]
+#[repr(u16)]
+pub enum AssignmentsType {
+    Revocation = 0,
+    Extension = 1,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Display, ToPrimitive, FromPrimitive)]
+#[display_from(Debug)]
+#[repr(u16)]
+pub enum TransitionType {
+    Identity = 0,
+}
+
+pub fn schema() -> Schema {
+    Schema {
+        field_types: type_map! {
+            FieldType::Name => DataFormat::String(256),
+            FieldType::Format => DataFormat::Unsigned(Bits::Bit16, 0, core::u16::MAX as u128),
+            FieldType::Identity => DataFormat::Bytes(core::u16::MAX),
+            FieldType::Cryptography => DataFormat::Unsigned(Bits::Bit16, 0, core::u16::MAX as u128),
+            FieldType::PublicKey => DataFormat::Bytes(core::u16::MAX),
+            FieldType::Signature => DataFormat::Bytes(core::u16::MAX),
+            // While UNIX timestamps allow negative numbers; in context of RGB Schema, assets
+            // can't be issued in the past before RGB or Bitcoin even existed; so we prohibit
+            // all the dates before RGB release
+            // TODO: Update lower limit with the first RGB release
+            // Current lower time limit is 07/04/2020 @ 1:54pm (UTC)
+            FieldType::ValidFrom => DataFormat::Integer(Bits::Bit64, 1593870844, core::i64::MAX as i128)
+        },
+        assignment_types: type_map! {
+            AssignmentsType::Revocation => StateSchema {
+                format: StateFormat::Declarative,
+                abi: bmap! {}
+            },
+            AssignmentsType::Extension => StateSchema {
+                format: StateFormat::Declarative,
+                abi: bmap! {}
+            }
+        },
+        genesis: GenesisSchema {
+            metadata: type_map! {
+                FieldType::Name => Occurences::Once,
+                FieldType::Format => Occurences::Once,
+                FieldType::Identity => Occurences::Once,
+                FieldType::Cryptography => Occurences::Once,
+                FieldType::PublicKey => Occurences::Once,
+                FieldType::Signature => Occurences::Once,
+                FieldType::ValidFrom => Occurences::Once
+            },
+            defines: type_map! {
+                AssignmentsType::Revocation => Occurences::Once,
+                AssignmentsType::Extension => Occurences::NoneOrUpTo(None)
+            },
+            abi: bmap! {
+                AssignmentAction::Validate => script::Procedure::Standard(script::StandardProcedure::IdentityValidate)
+            },
+        },
+        transitions: type_map! {
+            TransitionType::Identity => TransitionSchema {
+                metadata: type_map! {
+                    FieldType::Name => Occurences::Once,
+                    FieldType::Format => Occurences::Once,
+                    FieldType::Identity => Occurences::Once,
+                    FieldType::Cryptography => Occurences::Once,
+                    FieldType::PublicKey => Occurences::Once,
+                    FieldType::Signature => Occurences::Once,
+                    FieldType::ValidFrom => Occurences::Once
+                },
+                closes: type_map! {
+                    AssignmentsType::Revocation => Occurences::NoneOrUpTo(None),
+                    AssignmentsType::Extension => Occurences::NoneOrUpTo(None),
+                },
+                defines: type_map! {
+                    AssignmentsType::Revocation => Occurences::Once,
+                    AssignmentsType::Extension => Occurences::NoneOrUpTo(None)
+                },
+                abi: bmap! {
+                    AssignmentAction::Validate => script::Procedure::Standard(script::StandardProcedure::IdentityValidate)
+                }
+            }
+        },
+    }
+}
+
+impl Neg for FieldType {
+    type Output = usize;
+
+    fn neg(self) -> Self::Output {
+        self.to_usize().unwrap()
+    }
+}
+
+impl Neg for AssignmentsType {
+    type Output = usize;
+
+    fn neg(self) -> Self::Output {
+        self.to_usize().unwrap()
+    }
+}
+
+impl Neg for TransitionType {
+    type Output = usize;
+
+    fn neg(self) -> Self::Output {
+        self.to_usize().unwrap()
+    }
+}


### PR DESCRIPTION
The schema solves two main problems:
1. Linking multiple identities upon request, while keeping their relation anonymous otherwise
2. Keeping ability to globally verify that certain identity/public key was not revoked, and do that w/o use of any centralized registry.

Schema consists of identical state transitions, such that past history can be cut at any level and each state transition may be validated as genesis.

Identity is a:
1) public key (with ability to define a cryptographic function)
2) corresponding signature on identity data, proving ownership of it
3) identity data, serialized according to a certain format

Each identity can be revoked, which is defined by a single present seal.

New identities are created as children of other identities; either during revocation or extension procedure. This fact, as specified above, can be hidden, when identity issuing state transition is converted into genesis, not showing its ancestors.

Validation is simple: it must check that public key and signature match, and signature signs identity data, serialized in a correct form (according to the specified format).

Link between identities is established when a subgraph linking to identities up to a certain ancestor is revealed.

Actions attributed to identities via public keys; i.e. anybody can sign with his identity key a key of other person, and if that person will keep the signature data it will prove the identity. This is not part of RGB and is outside of the schema; so usual Web of Trust or other protocols may be followed.

This, for instance, can be used to build reputation systems, where reputation will be linked/attributed not to a single public key, but to a set of public keys, making revocation procedures possible and enhancing anonymity (i.e. reputation can be split across multiple identities and joined when needed).

Another use case for the schema is anonymous voting rights, when a person can use unrelated keys for blind signatures during the voting procedure and still be able to prove the fact of the vote was done by the holder of the rights.