### PR TITLE
Changes Blinding factor from 32 bit to 64 bit.

### DIFF
--- a/src/cli/fungible.rs
+++ b/src/cli/fungible.rs
@@ -80,7 +80,7 @@ pub enum Command {
         outpoint: OutPoint,
 
         /// Outpoint blinding factor (generated when the invoice was created)
-        blinding_factor: u32,
+        blinding_factor: u64,
     },
 
     Forget {
@@ -285,7 +285,7 @@ impl Command {
         mut runtime: Runtime,
         filename: PathBuf,
         outpoint: OutPoint,
-        blinding_factor: u32,
+        blinding_factor: u64,
     ) -> Result<(), Error> {
         use lnpbp::strict_encoding::strict_encode;
 

--- a/src/contracts/fungible/data/outcoins.rs
+++ b/src/contracts/fungible/data/outcoins.rs
@@ -46,7 +46,7 @@ impl Outcoins {
     pub fn seal_definition(&self) -> SealDefinition {
         use lnpbp::bitcoin::secp256k1::rand::{self, RngCore};
         let mut rng = rand::thread_rng();
-        let entropy = rng.next_u32(); // Not an amount blinding factor but outpoint blinding
+        let entropy = rng.next_u64(); // Not an amount blinding factor but outpoint blinding
         match self.txid {
             Some(txid) => SealDefinition::TxOutpoint(bp::blind::OutpointReveal {
                 blinding: entropy,

--- a/src/util/seal_spec.rs
+++ b/src/util/seal_spec.rs
@@ -36,7 +36,7 @@ impl SealSpec {
     pub fn seal_definition(&self) -> SealDefinition {
         use lnpbp::bitcoin::secp256k1::rand::{self, RngCore};
         let mut rng = rand::thread_rng();
-        let entropy = rng.next_u32(); // Not an amount blinding factor but outpoint blinding
+        let entropy = rng.next_u64(); // Not an amount blinding factor but outpoint blinding
         match self.txid {
             Some(txid) => SealDefinition::TxOutpoint(bp::blind::OutpointReveal {
                 blinding: entropy,


### PR DESCRIPTION
This is an upstream fix for [PR#52](https://github.com/LNP-BP/rust-lnpbp/pull/52) in rust-lnpbp.

Which modifies the blinding factor from 32 bit to 64 bit.

Compilation succeeds with the rust-lnpbp branch: https://github.com/rajarshimaitra/rust-lnpbp/tree/64bit-blind   