### PR TITLE
Improved android documentation and build script

### DIFF
--- a/ffi/android/library/README.md
+++ b/ffi/android/library/README.md
@@ -1,13 +1,16 @@
 # Building the Android Bindings
 
+* Install bash
+* Install rustup
 * Install Swig 4.0
 * Install cmake (used to build zmq)
-* Install the Android NDK and set the env variable NDK_HOME to the its base path
+* Install the Android SDK and export the env variable `ANDROID_SDK_ROOT` to its base path
+* Install the Android NDK (version `20.0.5594570`) and export the env variable `NDK_HOME` to its base path
 * Install the four cargo targets:
 ```
 rustup target add aarch64-linux-android x86_64-linux-android armv7-linux-androideabi i686-linux-android
 ```
-* Update your `~/.cargo/config` file to set the correct linker and ar command for each target (expand `NDK_HOME` manually):
+* Update your `~/.cargo/config` file to set the correct linker and ar command for each target (expand `<NDK_HOME>` manually):
 ```
 [target.aarch64-linux-android]
 ar = "<NDK_HOME>/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
@@ -25,5 +28,6 @@ linker = "<NDK_HOME>/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-andr
 ar = "<NDK_HOME>/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android-ar"
 linker = "<NDK_HOME>/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android26-clang"
 ```
-* Run `./gradlew build`
-* The artifacts are in `./library/build/outputs/aar/`
+* Update the `PATH` in `build_rust.sh` script if you're not building from x86_64
+* Run `./gradlew build` (if something fails, manually run the `build_rust.sh` script for a better error report)
+* The artifacts (debug and release versions) will be generated in `./library/build/outputs/aar/`

--- a/ffi/android/library/build_rust.sh
+++ b/ffi/android/library/build_rust.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Update this line accordingly if you are not building *from* x86_64
@@ -14,18 +14,18 @@ swig -java -c++ -package "org.lnpbp.rgbnode_autogen" -outdir library/src/main/ja
 
 mkdir -p library/src/main/jniLibs/arm64-v8a library/src/main/jniLibs/x86_64 library/src/main/jniLibs/armeabi-v7a library/src/main/jniLibs/x86
 
-aarch64-linux-android21-clang++ -shared swig_wrap.cxx -L../../../target/aarch64-linux-android/debug/ -lrgb -o library/src/main/jniLibs/arm64-v8a/librgb_node.so
+aarch64-linux-android21-clang++ -shared swig_wrap.cxx -L../../../target/aarch64-linux-android/debug/ -lrgb -o library/src/main/jniLibs/arm64-v8a/librgb_node.so -fPIC
 cp -v ../../../target/aarch64-linux-android/debug/librgb.so library/src/main/jniLibs/arm64-v8a/
 cp -v $NDK_HOME/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_shared.so library/src/main/jniLibs/arm64-v8a/
 
-x86_64-linux-android21-clang++ -shared swig_wrap.cxx -L../../../target/x86_64-linux-android/debug/ -lrgb -o library/src/main/jniLibs/x86_64/librgb_node.so
+x86_64-linux-android21-clang++ -shared swig_wrap.cxx -L../../../target/x86_64-linux-android/debug/ -lrgb -o library/src/main/jniLibs/x86_64/librgb_node.so -fPIC
 cp -v ../../../target/x86_64-linux-android/debug/librgb.so library/src/main/jniLibs/x86_64/
 cp -v $NDK_HOME/sources/cxx-stl/llvm-libc++/libs/x86_64/libc++_shared.so library/src/main/jniLibs/x86_64/
 
-armv7a-linux-androideabi21-clang++ -shared swig_wrap.cxx -L../../../target/armv7-linux-androideabi/debug/ -lrgb -o library/src/main/jniLibs/armeabi-v7a/librgb_node.so
+armv7a-linux-androideabi21-clang++ -shared swig_wrap.cxx -L../../../target/armv7-linux-androideabi/debug/ -lrgb -o library/src/main/jniLibs/armeabi-v7a/librgb_node.so -fPIC
 cp -v ../../../target/armv7-linux-androideabi/debug/librgb.so library/src/main/jniLibs/armeabi-v7a/
 cp -v $NDK_HOME/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so library/src/main/jniLibs/armeabi-v7a/
 
-i686-linux-android21-clang++ -shared swig_wrap.cxx -L../../../target/i686-linux-android/debug/ -lrgb -o library/src/main/jniLibs/x86/librgb_node.so
+i686-linux-android21-clang++ -shared swig_wrap.cxx -L../../../target/i686-linux-android/debug/ -lrgb -o library/src/main/jniLibs/x86/librgb_node.so -fPIC
 cp -v ../../../target/i686-linux-android/debug/librgb.so library/src/main/jniLibs/x86/
 cp -v $NDK_HOME/sources/cxx-stl/llvm-libc++/libs/x86/libc++_shared.so library/src/main/jniLibs/x86/


### PR DESCRIPTION
This PR adds some useful info to the android library build documentation and adds the `-fPIC` flag to the build process, to avoid "text relocations" issues.

I also changed the `build_rust.sh` interpreter from `sh` to `bash`, since `set -o pipefail` is a bashism that on `sh` produces the `set: Illegal option -o pipefail` error. If you prefer to use `sh` instead of `bash`, we can find an alternative solution.