### PR TITLE
[WIP] Sqlite Database engine for asset cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ zmq = "~0.9.2"
 tiny_http = "~0.7.0"
 prometheus = "~0.9.0"
 electrum-client = "=0.3.0-beta.1"
+diesel = { version = "1.4.4", features = ["sqlite", "uuid", "numeric", "chrono"] }
 
 [dependencies.lnpbp]
 git = "https://github.com/LNP-BP/rust-lnpbp"

--- a/db/cache/diesel.toml
+++ b/db/cache/diesel.toml
@@ -1,0 +1,5 @@
+# For documentation on how to configure this file,
+# see diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "../../src/contracts/fungible/cache/schema.rs"

--- a/db/cache/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/db/cache/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,4 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+

--- a/db/cache/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/db/cache/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,19 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+

--- a/db/cache/migrations/2020-03-21-151310_base/down.sql
+++ b/db/cache/migrations/2020-03-21-151310_base/down.sql
@@ -1,0 +1,7 @@
+-- This file should undo anything in `up.sql`
+
+drop table assets;
+drop table supply_table;
+drop table utxo_table;
+drop table allocations;
+drop table issues;

--- a/db/cache/migrations/2020-03-21-151310_base/up.sql
+++ b/db/cache/migrations/2020-03-21-151310_base/up.sql
@@ -1,0 +1,51 @@
+-- Your SQL goes here
+
+create table sql_assets(
+    id INTEGER PRIMARY KEY not null,
+    contract_id text not null,
+    ticker text not null,
+    asset_name text not null,
+    asset_description text,
+    known_circulating_supply bigint not null,
+    is_issued_known boolean,
+    max_cap bigint not null,
+    chain text not null,
+    fractional_bits blob not null,
+    asset_date datetime not null
+);
+
+SELECT diesel_manage_updated_at('sql_assets');
+
+create table sql_issues(
+    id integer PRIMARY key not null,
+    sql_asset_id integer not null,
+    node_id text not null,
+    contract_id text not null,
+    amount bigint not null,
+    origin_txid text,
+    origin_vout integer
+);
+
+create table sql_inflation(
+    id integer PRIMARY KEY not null,
+    sql_asset_id integer not null,
+    outpoint_txid text,
+    outpoint_vout integer,
+    accounting_amount bigint not null
+); 
+
+create table sql_allocation_utxo(
+    id INTEGER PRIMARY key not null,
+    sql_asset_id integer not null,
+    txid text not null,
+    vout INTEGER not null
+);
+
+create table sql_allocations(
+    id INTEGER PRIMARY key not null,
+    sql_allocation_utxo_id integer not null,
+    node_id text not null,
+    assignment_index integer not null,
+    amount bigint not null,
+    blinding text not null 
+);

--- a/src/cli/fungible.rs
+++ b/src/cli/fungible.rs
@@ -169,7 +169,6 @@ impl Command {
                     DataFormat::Json => serde_json::from_slice(&data)?,
                     DataFormat::Toml => toml::from_slice(&data)?,
                     DataFormat::StrictEncode => unimplemented!(),
-                    DataFormat::Sqlite => unimplemented!(),
                 };
                 let short: Vec<HashMap<&str, String>> = assets
                     .iter()

--- a/src/cli/fungible.rs
+++ b/src/cli/fungible.rs
@@ -169,6 +169,7 @@ impl Command {
                     DataFormat::Json => serde_json::from_slice(&data)?,
                     DataFormat::Toml => toml::from_slice(&data)?,
                     DataFormat::StrictEncode => unimplemented!(),
+                    DataFormat::Sqlite => unimplemented!(),
                 };
                 let short: Vec<HashMap<&str, String>> = assets
                     .iter()

--- a/src/contracts/fungible/cache/file.rs
+++ b/src/contracts/fungible/cache/file.rs
@@ -21,7 +21,6 @@ use lnpbp::bitcoin;
 use lnpbp::rgb::prelude::*;
 
 use super::Cache;
-use crate::error::{BootstrapError, ServiceErrorDomain};
 use crate::fungible::cache::CacheError;
 use crate::fungible::Asset;
 use crate::util::file::*;
@@ -53,18 +52,6 @@ pub enum FileCacheError {
 
     #[from(std::option::NoneError)]
     NotFound,
-}
-
-impl From<FileCacheError> for ServiceErrorDomain {
-    fn from(_: FileCacheError) -> Self {
-        ServiceErrorDomain::Cache
-    }
-}
-
-impl From<FileCacheError> for BootstrapError {
-    fn from(_: FileCacheError) -> Self {
-        BootstrapError::CacheError
-    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Display)]

--- a/src/contracts/fungible/cache/file.rs
+++ b/src/contracts/fungible/cache/file.rs
@@ -145,7 +145,6 @@ impl FileCache {
                 toml::from_str(&data)?
             }
             DataFormat::StrictEncode => unimplemented!(),
-            DataFormat::Sqlite => unimplemented!(),
         };
         Ok(())
     }
@@ -160,7 +159,6 @@ impl FileCache {
             DataFormat::Json => serde_json::to_writer(&f, &self.assets)?,
             DataFormat::Toml => f.write_all(&toml::to_vec(&self.assets)?)?,
             DataFormat::StrictEncode => unimplemented!(),
-            DataFormat::Sqlite => unimplemented!(),
         }
         Ok(())
     }
@@ -173,7 +171,6 @@ impl FileCache {
             DataFormat::Json => serde_json::to_vec(&assets)?,
             DataFormat::Toml => toml::to_vec(&assets)?,
             DataFormat::StrictEncode => unimplemented!(),
-            DataFormat::Sqlite => unimplemented!(),
         })
     }
 }

--- a/src/contracts/fungible/cache/file.rs
+++ b/src/contracts/fungible/cache/file.rs
@@ -145,6 +145,7 @@ impl FileCache {
                 toml::from_str(&data)?
             }
             DataFormat::StrictEncode => unimplemented!(),
+            DataFormat::Sqlite => unimplemented!(),
         };
         Ok(())
     }
@@ -159,6 +160,7 @@ impl FileCache {
             DataFormat::Json => serde_json::to_writer(&f, &self.assets)?,
             DataFormat::Toml => f.write_all(&toml::to_vec(&self.assets)?)?,
             DataFormat::StrictEncode => unimplemented!(),
+            DataFormat::Sqlite => unimplemented!(),
         }
         Ok(())
     }
@@ -171,6 +173,7 @@ impl FileCache {
             DataFormat::Json => serde_json::to_vec(&assets)?,
             DataFormat::Toml => toml::to_vec(&assets)?,
             DataFormat::StrictEncode => unimplemented!(),
+            DataFormat::Sqlite => unimplemented!(),
         })
     }
 }

--- a/src/contracts/fungible/cache/mod.rs
+++ b/src/contracts/fungible/cache/mod.rs
@@ -14,8 +14,9 @@
 mod cache;
 mod file;
 pub(crate) mod models;
-mod schema;
-pub(crate) mod sql;
+pub(crate) mod schema;
+mod sql;
 
 pub use cache::{Cache, CacheError};
 pub use file::{FileCache, FileCacheConfig, FileCacheError};
+pub use sql::{SqlCache, SqlCacheConfig, SqlCacheError};

--- a/src/contracts/fungible/cache/mod.rs
+++ b/src/contracts/fungible/cache/mod.rs
@@ -13,6 +13,9 @@
 
 mod cache;
 mod file;
+pub(crate) mod models;
+mod schema;
+pub(crate) mod sql;
 
 pub use cache::{Cache, CacheError};
 pub use file::{FileCache, FileCacheConfig, FileCacheError};

--- a/src/contracts/fungible/cache/models.rs
+++ b/src/contracts/fungible/cache/models.rs
@@ -1,0 +1,397 @@
+use ::std::collections::BTreeMap;
+
+use crate::contracts::fungible::cache::schema as cache_schema;
+use cache_schema::sql_allocation_utxo::dsl::sql_allocation_utxo as sql_allocation_utxo_table;
+use cache_schema::sql_allocations::dsl::sql_allocations as sql_allocation_table;
+use cache_schema::sql_assets::dsl::sql_assets as sql_asset_table;
+use cache_schema::sql_inflation::dsl::sql_inflation as sql_inflation_table;
+use cache_schema::sql_issues::dsl::sql_issues as sql_issue_table;
+use cache_schema::*;
+
+use super::sql::SqlCacheError;
+use crate::contracts::fungible::data::{AccountingAmount, AccountingValue, Allocation, Asset};
+use diesel::prelude::*;
+use lnpbp::bitcoin::{OutPoint, Txid};
+use lnpbp::bitcoin_hashes::hex::{FromHex, ToHex};
+use lnpbp::bp::Chain;
+
+/// All the sqlite table structures are defined here.
+/// There are 5 tables namely Asset, Issue, Inflation, AllocationUtxo
+/// and Allocation. The Asset is the major table, and all other tables 
+/// are associated with Asset by sql_asset_id field.
+
+#[derive(Queryable, Insertable, Identifiable, Clone, Debug)]
+#[table_name = "sql_assets"]
+pub struct SqlAsset {
+    pub id: i32,
+    pub contract_id: String,
+    pub ticker: String,
+    pub asset_name: String,
+    pub asset_description: Option<String>,
+    pub known_circulating_supply: i64,
+    pub is_issued_known: Option<bool>,
+    pub max_cap: i64,
+    pub chain: String,
+    pub fractional_bits: Vec<u8>,
+    pub asset_date: chrono::NaiveDateTime,
+}
+
+impl SqlAsset {
+    /// Create an Sqlite Asset entry from a given Asset data structure.
+    /// Note, only the metadata are written into the Asset table,
+    /// All other data for the Asset are to be found from fetching other 
+    /// table entries associated with this Asset entry. So they are implicitly defined
+    /// in the table schema.   
+    pub fn from_asset(asset: &Asset, connection: &SqliteConnection) -> Result<Self, SqlCacheError> {
+        // Find the last entry and increase index by 1
+        let last_asset = sql_asset_table
+            .load::<SqlAsset>(connection)?
+            .last()
+            .cloned();
+
+        Ok(Self {
+            id: match last_asset {
+                Some(asset) => asset.id + 1,
+                None => 0,
+            },
+            contract_id: asset.id().clone().to_hex(),
+            ticker: asset.ticker().clone(),
+            asset_name: asset.name().clone(),
+            asset_description: asset.description().clone(),
+            known_circulating_supply: asset.supply().known_circulating().accounting_value() as i64,
+            is_issued_known: asset.supply().is_issued_known().clone(),
+            max_cap: asset.supply().max_cap().accounting_value() as i64,
+            chain: write_chain_to_table(asset.chain())?,
+            fractional_bits: vec![asset.fractional_bits().clone()],
+            asset_date: asset.date().clone(),
+        })
+    }
+}
+
+// TODO: Implement handling for other chain variants
+pub fn read_chain_from_table(table_value: String) -> Result<Chain, SqlCacheError> {
+    match &table_value[..] {
+        "MainNet" => Ok(Chain::Mainnet),
+        "TestNet3" => Ok(Chain::Testnet3),
+        _ => Err(SqlCacheError::GenericError(
+            "Unsupported Chain value".to_string(),
+        )),
+    }
+}
+
+pub fn write_chain_to_table(chain: &Chain) -> Result<String, SqlCacheError> {
+    match chain {
+        Chain::Mainnet => Ok(String::from("MainNet")),
+        Chain::Testnet3 => Ok(String::from("TestNet3")),
+        _ => Err(SqlCacheError::GenericError(
+            "Unsupported Chain value".to_string(),
+        )),
+    }
+}
+
+#[derive(Queryable, Insertable, Identifiable, Associations, Clone, Debug)]
+#[table_name = "sql_inflation"]
+#[belongs_to(SqlAsset)]
+/// There is no separate field for unknown inflation amount in the db.
+/// An Inflation structure with None type outpoint is used
+/// as unknown inflation value for the associated asset.
+pub struct SqlInflation {
+    pub id: i32,
+    pub sql_asset_id: i32,
+    pub outpoint_txid: Option<String>,
+    pub outpoint_vout: Option<i32>,
+    pub accounting_amount: i64,
+}
+
+impl SqlInflation {
+    pub fn from_asset(
+        asset: &Asset,
+        table_asset: &SqlAsset,
+        connection: &SqliteConnection,
+    ) -> Result<Vec<Self>, SqlCacheError> {
+
+        // Find the last inflation entry and increase id from there
+        let last_inflation = sql_inflation_table
+            .load::<SqlInflation>(connection)?
+            .last()
+            .cloned();
+
+        let known_inflations = asset.known_inflation();
+
+        let mut result = vec![];
+
+        // Create Inflation table entries from Asset known_inflation data
+        for (index, item) in known_inflations.into_iter().enumerate() {
+            let sql_inflation = Self {
+                id: match last_inflation.clone() {
+                    Some(inflation) => inflation.id + index as i32 + 1,
+                    None => 0 + index as i32,
+                },
+                sql_asset_id: table_asset.id,
+                outpoint_txid: Some(item.0.txid.to_hex()),
+                outpoint_vout: Some(item.0.vout as i32),
+                accounting_amount: item.1.accounting_value() as i64,
+            };
+
+            result.push(sql_inflation);
+        }
+
+        // We need to keep track on the last added item id 
+        // in the above inflation entry as we need to add
+        // unknown inflation entry next.
+        let last_added_id;
+
+        if let Some(item) = result.last() {
+            last_added_id = item.id;
+        } else {
+            last_added_id = 0;
+        }
+
+        // Push the unknown inflation entry with txid and vout as None.
+        result.push(Self {
+            id: last_added_id + 1,
+            sql_asset_id: table_asset.id,
+            outpoint_txid: None,
+            outpoint_vout: None,
+            accounting_amount: asset.unknown_inflation().accounting_value() as i64,
+        });
+
+        Ok(result)
+    }
+}
+
+/// Read Inflation data associated to a table Asset entry
+/// found at a given database connection
+/// This returns the known_inflation and unknown inflation data structures
+/// for the given asset in tupple. Which then can be directly used as fields 
+/// in Asset data structure.
+pub fn read_inflation(
+    asset: &SqlAsset,
+    connection: &SqliteConnection,
+) -> Result<(BTreeMap<OutPoint, AccountingAmount>, AccountingAmount), SqlCacheError> {
+
+    let inflations = SqlInflation::belonging_to(asset).load::<SqlInflation>(connection)?;
+
+    let mut known_inflation_map = BTreeMap::new();
+
+    let mut unknown = AccountingAmount::default();
+
+    for known_inflation in inflations {
+        match (known_inflation.outpoint_txid, known_inflation.outpoint_vout) {
+            // If both txid and vout are present add them to known_inflation_map
+            (Some(txid), Some(vout)) => {
+                known_inflation_map.insert(
+                    OutPoint {
+                        txid: Txid::from_hex(&txid[..])?,
+                        vout: vout as u32,
+                    },
+                    AccountingAmount::from_fractioned_accounting_value(
+                        asset.fractional_bits[0],
+                        known_inflation.accounting_amount as AccountingValue,
+                    ),
+                );
+            }
+            // For everything else, add them to unknown inflation
+            _ => {
+                unknown = AccountingAmount::from_fractioned_accounting_value(
+                    asset.fractional_bits[0],
+                    known_inflation.accounting_amount as AccountingValue,
+                );
+            }
+        }
+    }
+
+    Ok((known_inflation_map, unknown))
+}
+
+#[derive(Queryable, Insertable, Identifiable, Associations, Clone, Debug)]
+#[table_name = "sql_issues"]
+#[belongs_to(SqlAsset)]
+pub struct SqlIssue {
+    pub id: i32,
+    pub sql_asset_id: i32,
+    pub node_id: String,
+    pub contract_id: String,
+    pub amount: i64,
+    pub origin_txid: Option<String>,
+    pub origin_vout: Option<i32>,
+}
+
+impl SqlIssue {
+    /// Create vectro of Issue table entries from a given Asset data
+    pub fn from_asset(
+        asset: &Asset,
+        table_asset: &SqlAsset,
+        connection: &SqliteConnection,
+    ) -> Result<Vec<Self>, SqlCacheError> {
+
+        // get the last issue and increase id from there
+        let last_issue = sql_issue_table
+            .load::<SqlIssue>(connection)?
+            .last()
+            .cloned();
+
+        let asset_issues = asset.known_issues();
+
+        let mut result = vec![];
+
+        for (index, issue) in asset_issues.into_iter().enumerate() {
+            result.push(Self {
+                id: match last_issue.clone() {
+                    Some(issue) => issue.id + index as i32 + 1,
+                    None => 0 + index as i32,
+                },
+                sql_asset_id: table_asset.id,
+                node_id: issue.id().to_hex(),
+                contract_id: issue.asset_id().to_hex(),
+                amount: issue.amount().accounting_value() as i64,
+                origin_txid: match issue.origin() {
+                    Some(outpoint) => Some(outpoint.txid.to_hex()),
+                    None => None,
+                },
+                origin_vout: match issue.origin() {
+                    Some(outpoint) => Some(outpoint.vout as i32),
+                    None => None,
+                },
+            })
+        }
+        Ok(result)
+    }
+}
+
+/// AllocationUtxo and Allocation are associated tables with each other.
+/// Every AllocationUtxo is associated with an Asset entry.
+/// Every Allocation is associated with an AllocationUtxo.
+/// Together these two tables represent the `known_allocations` field
+/// in the Asset data structure.
+#[derive(
+    Queryable, Insertable, Identifiable, Associations, Clone, Debug, Ord, PartialOrd, Eq, PartialEq,
+)]
+#[table_name = "sql_allocation_utxo"]
+#[belongs_to(SqlAsset)]
+pub struct SqlAllocationUtxo {
+    pub id: i32,
+    pub sql_asset_id: i32,
+    pub txid: String,
+    pub vout: i32,
+}
+
+#[derive(Queryable, Insertable, Identifiable, Associations, Clone, Debug)]
+#[table_name = "sql_allocations"]
+#[belongs_to(SqlAllocationUtxo)]
+pub struct SqlAllocation {
+    pub id: i32,
+    pub sql_allocation_utxo_id: i32,
+    pub node_id: String,
+    pub assignment_index: i32,
+    pub amount: i64,
+    pub blinding: String,
+}
+
+/// Create a list of AllocationUtxo and Allocation table entry
+/// with correct associations between them.
+/// The AllocationUtxo entries are associated with the given Asset entry.
+/// 
+/// For a Given Assets structure, this will create the correct AllocationUtxo and 
+/// Allocation table entries to write to the database
+pub fn create_allocation_from_asset(
+    asset: &Asset,
+    table_asset: &SqlAsset,
+    connection: &SqliteConnection,
+) -> Result<(Vec<SqlAllocationUtxo>, Vec<SqlAllocation>), SqlCacheError> {
+
+    // get the last allocationutxo and allocation id
+    // increase id from there
+    let last_alloc_utxo = sql_allocation_utxo_table
+        .load::<SqlAllocationUtxo>(connection)?
+        .last()
+        .cloned();
+    let last_alloc = sql_allocation_table
+        .load::<SqlAllocation>(connection)?
+        .last()
+        .cloned();
+
+    let allocations = asset.known_allocations();
+
+    let mut utxos = vec![];
+    let mut allocation_vec = vec![];
+
+    let mut added_allocations = 0;
+
+    for (index, item) in allocations.into_iter().enumerate() {
+        let this_utxo_id = match last_alloc_utxo.clone() {
+            Some(alloc_utxo) => alloc_utxo.id + index as i32 + 1,
+            None => 0 + index as i32,
+        };
+        utxos.push(SqlAllocationUtxo {
+            id: this_utxo_id,
+            sql_asset_id: table_asset.id,
+            txid: item.0.txid.to_hex(),
+            vout: item.0.vout as i32,
+        });
+        for (index, alloc) in item.1.into_iter().enumerate() {
+            allocation_vec.push(SqlAllocation {
+                id: match last_alloc.clone() {
+                    Some(alloc) => alloc.id + added_allocations + index as i32 + 1,
+                    None => 0 + added_allocations + index as i32,
+                },
+                sql_allocation_utxo_id: this_utxo_id,
+                node_id: alloc.node_id().to_hex(),
+                assignment_index: alloc.index().clone() as i32,
+                amount: alloc.value().value as i64,
+                blinding: alloc.value().blinding.0.to_vec().to_hex(),
+            });
+        }
+        added_allocations += item.1.len() as i32;
+    }
+
+    Ok((utxos, allocation_vec))
+}
+
+
+/// Read the associated AllocationUtxo and Allocation entries
+/// with the given Asset entry executed over the given database
+/// connection.
+/// This will return a BtreeMap which can be directly used as the
+/// `known_allocations` field in the Asset Data structure.
+pub fn read_allocations(
+    asset: &SqlAsset,
+    connection: &SqliteConnection,
+) -> Result<BTreeMap<OutPoint, Vec<Allocation>>, SqlCacheError> {
+
+    // Get the associated utxo with asset entry
+    let utxo_list = SqlAllocationUtxo::belonging_to(asset).load::<SqlAllocationUtxo>(connection)?;
+
+    // Get the associated allocations with the above utxos
+    let allocations = SqlAllocation::belonging_to(&utxo_list)
+        .load::<SqlAllocation>(connection)?
+        .grouped_by(&utxo_list);
+
+    // Group them accordingly and zip the two vectors by correct groupings
+    let grouped_allocation = utxo_list.into_iter().zip(&allocations).collect::<Vec<_>>();
+
+    let mut allocation_map = BTreeMap::new();
+
+    grouped_allocation.into_iter().for_each(|item| {
+        allocation_map.insert(item.0, item.1);
+    });
+
+    // Read the zipped data into a BtreeMap
+    let mut known_allocation = BTreeMap::new();
+
+    for item in allocation_map.into_iter() {
+        let mut allocations = vec![];
+        for allocation in item.1 {
+            allocations.push(Allocation::from_sql_allocation(&allocation, &item.0)?);
+        }
+        known_allocation.insert(
+            OutPoint {
+                txid: Txid::from_hex(&item.0.txid[..])?,
+                vout: item.0.vout as u32,
+            },
+            allocations,
+        );
+    }
+
+    Ok(known_allocation)
+}

--- a/src/contracts/fungible/cache/models.rs
+++ b/src/contracts/fungible/cache/models.rs
@@ -13,8 +13,6 @@ use crate::contracts::fungible::data::{AccountingAmount, AccountingValue, Alloca
 use diesel::prelude::*;
 use lnpbp::bitcoin::{OutPoint, Txid};
 use lnpbp::bitcoin_hashes::hex::{FromHex, ToHex};
-use lnpbp::bp::Chain;
-
 /// All the sqlite table structures are defined here.
 /// There are 5 tables namely Asset, Issue, Inflation, AllocationUtxo
 /// and Allocation. The Asset is the major table, and all other tables
@@ -61,31 +59,10 @@ impl SqlAsset {
             known_circulating_supply: asset.supply().known_circulating().accounting_value() as i64,
             is_issued_known: asset.supply().is_issued_known().clone(),
             max_cap: asset.supply().max_cap().accounting_value() as i64,
-            chain: write_chain_to_table(asset.chain())?,
+            chain: asset.chain().to_string(),
             fractional_bits: vec![asset.fractional_bits().clone()],
             asset_date: asset.date().clone(),
         })
-    }
-}
-
-// TODO: Implement handling for other chain variants
-pub fn read_chain_from_table(table_value: String) -> Result<Chain, SqlCacheError> {
-    match &table_value[..] {
-        "MainNet" => Ok(Chain::Mainnet),
-        "TestNet3" => Ok(Chain::Testnet3),
-        _ => Err(SqlCacheError::GenericError(
-            "Unsupported Chain value".to_string(),
-        )),
-    }
-}
-
-pub fn write_chain_to_table(chain: &Chain) -> Result<String, SqlCacheError> {
-    match chain {
-        Chain::Mainnet => Ok(String::from("MainNet")),
-        Chain::Testnet3 => Ok(String::from("TestNet3")),
-        _ => Err(SqlCacheError::GenericError(
-            "Unsupported Chain value".to_string(),
-        )),
     }
 }
 

--- a/src/contracts/fungible/cache/models.rs
+++ b/src/contracts/fungible/cache/models.rs
@@ -17,7 +17,7 @@ use lnpbp::bp::Chain;
 
 /// All the sqlite table structures are defined here.
 /// There are 5 tables namely Asset, Issue, Inflation, AllocationUtxo
-/// and Allocation. The Asset is the major table, and all other tables 
+/// and Allocation. The Asset is the major table, and all other tables
 /// are associated with Asset by sql_asset_id field.
 
 #[derive(Queryable, Insertable, Identifiable, Clone, Debug)]
@@ -39,7 +39,7 @@ pub struct SqlAsset {
 impl SqlAsset {
     /// Create an Sqlite Asset entry from a given Asset data structure.
     /// Note, only the metadata are written into the Asset table,
-    /// All other data for the Asset are to be found from fetching other 
+    /// All other data for the Asset are to be found from fetching other
     /// table entries associated with this Asset entry. So they are implicitly defined
     /// in the table schema.   
     pub fn from_asset(asset: &Asset, connection: &SqliteConnection) -> Result<Self, SqlCacheError> {
@@ -109,7 +109,6 @@ impl SqlInflation {
         table_asset: &SqlAsset,
         connection: &SqliteConnection,
     ) -> Result<Vec<Self>, SqlCacheError> {
-
         // Find the last inflation entry and increase id from there
         let last_inflation = sql_inflation_table
             .load::<SqlInflation>(connection)?
@@ -136,7 +135,7 @@ impl SqlInflation {
             result.push(sql_inflation);
         }
 
-        // We need to keep track on the last added item id 
+        // We need to keep track on the last added item id
         // in the above inflation entry as we need to add
         // unknown inflation entry next.
         let last_added_id;
@@ -163,13 +162,12 @@ impl SqlInflation {
 /// Read Inflation data associated to a table Asset entry
 /// found at a given database connection
 /// This returns the known_inflation and unknown inflation data structures
-/// for the given asset in tupple. Which then can be directly used as fields 
+/// for the given asset in tupple. Which then can be directly used as fields
 /// in Asset data structure.
 pub fn read_inflation(
     asset: &SqlAsset,
     connection: &SqliteConnection,
 ) -> Result<(BTreeMap<OutPoint, AccountingAmount>, AccountingAmount), SqlCacheError> {
-
     let inflations = SqlInflation::belonging_to(asset).load::<SqlInflation>(connection)?;
 
     let mut known_inflation_map = BTreeMap::new();
@@ -224,7 +222,6 @@ impl SqlIssue {
         table_asset: &SqlAsset,
         connection: &SqliteConnection,
     ) -> Result<Vec<Self>, SqlCacheError> {
-
         // get the last issue and increase id from there
         let last_issue = sql_issue_table
             .load::<SqlIssue>(connection)?
@@ -291,15 +288,14 @@ pub struct SqlAllocation {
 /// Create a list of AllocationUtxo and Allocation table entry
 /// with correct associations between them.
 /// The AllocationUtxo entries are associated with the given Asset entry.
-/// 
-/// For a Given Assets structure, this will create the correct AllocationUtxo and 
+///
+/// For a Given Assets structure, this will create the correct AllocationUtxo and
 /// Allocation table entries to write to the database
 pub fn create_allocation_from_asset(
     asset: &Asset,
     table_asset: &SqlAsset,
     connection: &SqliteConnection,
 ) -> Result<(Vec<SqlAllocationUtxo>, Vec<SqlAllocation>), SqlCacheError> {
-
     // get the last allocationutxo and allocation id
     // increase id from there
     let last_alloc_utxo = sql_allocation_utxo_table
@@ -348,7 +344,6 @@ pub fn create_allocation_from_asset(
     Ok((utxos, allocation_vec))
 }
 
-
 /// Read the associated AllocationUtxo and Allocation entries
 /// with the given Asset entry executed over the given database
 /// connection.
@@ -358,7 +353,6 @@ pub fn read_allocations(
     asset: &SqlAsset,
     connection: &SqliteConnection,
 ) -> Result<BTreeMap<OutPoint, Vec<Allocation>>, SqlCacheError> {
-
     // Get the associated utxo with asset entry
     let utxo_list = SqlAllocationUtxo::belonging_to(asset).load::<SqlAllocationUtxo>(connection)?;
 

--- a/src/contracts/fungible/cache/schema.rs
+++ b/src/contracts/fungible/cache/schema.rs
@@ -1,0 +1,65 @@
+table! {
+    sql_allocation_utxo (id) {
+        id -> Integer,
+        sql_asset_id -> Integer,
+        txid -> Text,
+        vout -> Integer,
+    }
+}
+
+table! {
+    sql_allocations (id) {
+        id -> Integer,
+        sql_allocation_utxo_id -> Integer,
+        node_id -> Text,
+        assignment_index -> Integer,
+        amount -> BigInt,
+        blinding -> Text,
+    }
+}
+
+table! {
+    sql_assets (id) {
+        id -> Integer,
+        contract_id -> Text,
+        ticker -> Text,
+        asset_name -> Text,
+        asset_description -> Nullable<Text>,
+        known_circulating_supply -> BigInt,
+        is_issued_known -> Nullable<Bool>,
+        max_cap -> BigInt,
+        chain -> Text,
+        fractional_bits -> Binary,
+        asset_date -> Timestamp,
+    }
+}
+
+table! {
+    sql_inflation (id) {
+        id -> Integer,
+        sql_asset_id -> Integer,
+        outpoint_txid -> Nullable<Text>,
+        outpoint_vout -> Nullable<Integer>,
+        accounting_amount -> BigInt,
+    }
+}
+
+table! {
+    sql_issues (id) {
+        id -> Integer,
+        sql_asset_id -> Integer,
+        node_id -> Text,
+        contract_id -> Text,
+        amount -> BigInt,
+        origin_txid -> Nullable<Text>,
+        origin_vout -> Nullable<Integer>,
+    }
+}
+
+allow_tables_to_appear_in_same_query!(
+    sql_allocation_utxo,
+    sql_allocations,
+    sql_assets,
+    sql_inflation,
+    sql_issues,
+);

--- a/src/contracts/fungible/cache/sql.rs
+++ b/src/contracts/fungible/cache/sql.rs
@@ -10,3 +10,687 @@
 // You should have received a copy of the MIT License
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
+
+use diesel::prelude::*;
+use std::collections::HashMap;
+use std::{fmt, fs, fs::File};
+
+use crate::contracts::fungible::cache::schema as cache_schema;
+
+use lnpbp::bitcoin;
+use lnpbp::bitcoin_hashes::hex::FromHex;
+use lnpbp::rgb::ContractId;
+
+use cache_schema::sql_allocation_utxo::dsl::sql_allocation_utxo as sql_allocation_utxo_table;
+use cache_schema::sql_allocations::dsl::sql_allocations as sql_allocation_table;
+use cache_schema::sql_assets::dsl::sql_assets as sql_asset_table;
+use cache_schema::sql_inflation::dsl::sql_inflation as sql_inflation_table;
+use cache_schema::sql_issues::dsl::sql_issues as sql_issue_table;
+
+use crate::contracts::fungible::data::Asset;
+
+use crate::error::{BootstrapError, ServiceErrorDomain};
+use crate::DataFormat;
+use std::path::PathBuf;
+
+use super::cache::{Cache, CacheError};
+
+use super::models::*;
+
+#[derive(Debug, Display, Error, From)]
+#[display(Debug)]
+pub enum SqlCacheError {
+    #[from]
+    Io(std::io::Error),
+
+    #[from]
+    DieselError(diesel::result::Error),
+
+    #[from(bitcoin::hashes::hex::Error)]
+    HexDecodingError,
+
+    #[from]
+    GenericError(String),
+
+    #[from(std::option::NoneError)]
+    NotFound,
+}
+
+impl From<SqlCacheError> for ServiceErrorDomain {
+    fn from(_: SqlCacheError) -> Self {
+        ServiceErrorDomain::Cache
+    }
+}
+
+impl From<SqlCacheError> for BootstrapError {
+    fn from(_: SqlCacheError) -> Self {
+        BootstrapError::CacheError
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Display)]
+#[display(Debug)]
+pub struct SqlCacheConfig {
+    pub data_dir: PathBuf,
+    pub data_format: DataFormat,
+}
+
+impl SqlCacheConfig {
+    #[inline]
+    pub fn assets_dir(&self) -> PathBuf {
+        self.data_dir.clone()
+    }
+
+    #[inline]
+    pub fn assets_filename(&self) -> PathBuf {
+        self.assets_dir()
+            .join("assets")
+            .with_extension(self.data_format.extension())
+    }
+}
+
+/// Keeps all source/binary RGB contract data, stash etc
+pub struct SqlCache {
+    connection: SqliteConnection,
+    assets: HashMap<ContractId, Asset>,
+}
+
+impl fmt::Display for SqlCache {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:#?}", self.assets)
+    }
+}
+
+impl SqlCache {
+    pub fn new(config: &SqlCacheConfig) -> Result<Self, SqlCacheError> {
+        debug!("Instantiating RGB fungible assets storage (disk storage) ...");
+
+        let data_dir = config.data_dir.clone();
+        if !data_dir.exists() {
+            debug!(
+                "RGB fungible assets data directory '{:?}' is not found; creating one",
+                data_dir
+            );
+            fs::create_dir_all(data_dir)?;
+        }
+        let assets_dir = config.assets_dir();
+        if !assets_dir.exists() {
+            debug!(
+                "RGB fungible assets information directory '{:?}' is not found; creating one",
+                assets_dir
+            );
+            fs::create_dir_all(assets_dir)?;
+        }
+
+        // check for cached db file
+        let filename = config.assets_filename();
+
+        if filename.exists() {
+            // Create connection to db
+            let connection = SqliteConnection::establish(config.assets_filename().to_str()?)
+                .expect(&format!("Error connecting to asset.db"));
+
+            let mut sql_cache = Self {
+                connection,
+                assets: map![],
+            };
+
+            sql_cache.load()?;
+
+            Ok(sql_cache)
+        } else {
+            // If cached database not found create one and return empty cache
+            debug!("Initializing assets file {:?} ...", filename.to_str());
+            File::create(config.assets_filename())?;
+
+            // Create connection to db
+            let connection = SqliteConnection::establish(config.assets_filename().to_str()?)
+                .expect(&format!("Error connecting to asset.db"));
+
+            let sql_cache = Self {
+                connection,
+                assets: map![],
+            };
+
+            Ok(sql_cache)
+        }
+    }
+
+    pub fn load(&mut self) -> Result<(), SqlCacheError> {
+        // get the assets recorded in db
+        let assets = sql_asset_table.load::<SqlAsset>(&self.connection)?;
+
+        let mut asset_map = HashMap::new();
+
+        for asset in assets {
+            asset_map.insert(
+                ContractId::from_hex(&asset.contract_id[..])?,
+                Asset::from_sql_asset(&asset, &self.connection)?,
+            );
+        }
+
+        self.assets = asset_map;
+
+        Ok(())
+    }
+
+    /// Deletes and recreates the full database with updated cache
+    pub fn save(&self) -> Result<(), SqlCacheError> {
+        // Delet the existing data
+        diesel::delete(sql_asset_table).execute(&self.connection)?;
+        diesel::delete(sql_issue_table).execute(&self.connection)?;
+        diesel::delete(sql_inflation_table).execute(&self.connection)?;
+        diesel::delete(sql_allocation_utxo_table).execute(&self.connection)?;
+        diesel::delete(sql_allocation_table).execute(&self.connection)?;
+
+        // Create and write table entries from updated cached data
+        for item in self.assets.clone().into_iter() {
+            let table_asset = SqlAsset::from_asset(&item.1, &self.connection)?;
+            let table_issues = SqlIssue::from_asset(&item.1, &table_asset, &self.connection)?;
+
+            let table_inflations =
+                SqlInflation::from_asset(&item.1, &table_asset, &self.connection)?;
+
+            let (table_utxos, table_allocations) =
+                create_allocation_from_asset(&item.1, &table_asset, &self.connection)?;
+
+            diesel::insert_into(sql_asset_table)
+                .values(table_asset)
+                .execute(&self.connection)?;
+
+            for issue in table_issues {
+                diesel::insert_into(sql_issue_table)
+                    .values(issue)
+                    .execute(&self.connection)?;
+            }
+
+            for inflation in table_inflations {
+                diesel::insert_into(sql_inflation_table)
+                    .values(inflation)
+                    .execute(&self.connection)?;
+            }
+
+            for utxo in table_utxos {
+                diesel::insert_into(sql_allocation_utxo_table)
+                    .values(utxo)
+                    .execute(&self.connection)?;
+            }
+
+            for allocation in table_allocations {
+                diesel::insert_into(sql_allocation_table)
+                    .values(allocation)
+                    .execute(&self.connection)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Cache for SqlCache {
+    type Error = CacheError;
+
+    fn assets(&self) -> Result<Vec<&Asset>, CacheError> {
+        Ok(self.assets.values().collect())
+    }
+
+    #[inline]
+    fn asset(&self, id: ContractId) -> Result<&Asset, CacheError> {
+        Ok(self.assets.get(&id).ok_or(CacheError::DataIntegrityError(
+            "Asset is not known".to_string(),
+        ))?)
+    }
+
+    #[inline]
+    fn has_asset(&self, id: ContractId) -> Result<bool, CacheError> {
+        Ok(self.assets.contains_key(&id))
+    }
+
+    fn add_asset(&mut self, asset: Asset) -> Result<bool, CacheError> {
+        let exists = self.assets.insert(*asset.id(), asset).is_some();
+        self.save()?;
+        Ok(exists)
+    }
+
+    #[inline]
+    fn remove_asset(&mut self, id: ContractId) -> Result<bool, CacheError> {
+        let existed = self.assets.remove(&id).is_some();
+        self.save()?;
+        Ok(existed)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::contracts::fungible::data::Asset;
+    use chrono::NaiveDate;
+    use lnpbp::bitcoin_hashes::hex::FromHex;
+    use lnpbp::rgb::ContractId;
+
+    use cache_schema::sql_allocation_utxo::dsl::sql_allocation_utxo as sql_allocation_utxo_table;
+    use cache_schema::sql_allocations::dsl::sql_allocations as sql_allocation_table;
+    use cache_schema::sql_assets::dsl::sql_assets as sql_asset_table;
+    use cache_schema::sql_inflation::dsl::sql_inflation as sql_inflation_table;
+    use cache_schema::sql_issues::dsl::sql_issues as sql_issue_table;
+    use std::env;
+
+    // The following tests are ignored by default, because they will break
+    // Travis CI unless the build setup is updated (TODO). To run these tests, 
+    // 1. set an environment variable DATABASE_URL=~/.rgb.
+    // 2. manually remove the ignore flag and run the rgb-node/test/test_db.sh.
+    
+    #[test]
+    //#[ignore]
+    // Creates a sample table with sample asset data
+    fn test_create_tables() {
+        let database_url = env::var("DATABASE_URL")
+            .expect("Environment Variable 'DATABASE_URL' must be set to run this test");
+
+        let filepath = PathBuf::from(&database_url[..]);
+
+        let config = SqlCacheConfig {
+            data_dir: filepath,
+            data_format: DataFormat::Sqlite,
+        };
+
+        println!("{:#?}", config);
+
+        let cache = SqlCache::new(&config).unwrap();
+
+        let conn = cache.connection;
+        // Assets
+        for i in 0..2 {
+            match i {
+                0 => {
+                    let asset = SqlAsset {
+                        id: i,
+                        contract_id:
+                            "5bb162c7c84fa69bd263a12b277b82155787a03537691619fed731432f6855dc"
+                                .to_string(),
+                        ticker: "BTC".to_string(),
+                        asset_name: "Bitcoin".to_string(),
+                        asset_description: Some("I am satoshi".to_string()),
+                        known_circulating_supply: 20000,
+                        is_issued_known: Some(true),
+                        max_cap: 20000,
+                        chain: "MainNet".to_string(),
+                        fractional_bits: vec![0u8],
+                        asset_date: NaiveDate::from_ymd(2016, 7, 8).and_hms(9, 10, 11),
+                    };
+
+                    diesel::insert_into(sql_asset_table)
+                        .values(asset)
+                        .execute(&conn)
+                        .unwrap();
+                }
+
+                1 => {
+                    let asset = SqlAsset {
+                        id: i,
+                        contract_id:
+                            "7ce3b67036e32628fe5351f23d57186181dba3103b7e0a5d55ed511446f5a6a9"
+                                .to_string(),
+                        ticker: "ETH".to_string(),
+                        asset_name: "Ethereum".to_string(),
+                        asset_description: Some("I am Vitalik".to_string()),
+                        known_circulating_supply: 10000,
+                        is_issued_known: Some(true),
+                        max_cap: 10000,
+                        chain: "TestNet3".to_string(),
+                        fractional_bits: vec![0u8],
+                        asset_date: NaiveDate::from_ymd(2016, 7, 8).and_hms(9, 10, 11),
+                    };
+
+                    diesel::insert_into(sql_asset_table)
+                        .values(asset)
+                        .execute(&conn)
+                        .unwrap();
+                }
+
+                _ => {}
+            }
+        }
+
+        // Issues
+        for i in 0..6 {
+            match i {
+                0..=2 => {
+                    let issue = SqlIssue {
+                        id: i,
+                        sql_asset_id: 0,
+                        node_id: "2242ee7a53d9a1b67867891e9e5f2b0b80db0b0e6a983dd5cdc6df947385b554"
+                            .to_string(),
+                        contract_id:
+                            "8c6c655eec5a030abc95a3695d11e4fc13136a233a05caafb16b45b012648bc5"
+                                .to_string(),
+                        amount: 5000,
+                        origin_txid: Some(
+                            "7d167ebb0182ef02f3402d3e7b0233bf4de6f808330086a82d6dd1cf59c03ac0"
+                                .to_string(),
+                        ),
+                        origin_vout: Some(5),
+                    };
+
+                    diesel::insert_into(sql_issue_table)
+                        .values(issue)
+                        .execute(&conn)
+                        .unwrap();
+                }
+
+                3..=5 => {
+                    let issue = SqlIssue {
+                        id: i,
+                        sql_asset_id: 1,
+                        node_id: "282de45c37bf6f7070106b7cf8dddfb41f9c5133785ab680aec1347ad2fd670c"
+                            .to_string(),
+                        contract_id:
+                            "35e518ea2b087ea72e57b10c9768838eb86be9a49c14c72a914eb797ffbdcda4"
+                                .to_string(),
+                        amount: 5000,
+                        origin_txid: None,
+                        origin_vout: None,
+                    };
+
+                    diesel::insert_into(sql_issue_table)
+                        .values(issue)
+                        .execute(&conn)
+                        .unwrap();
+                }
+
+                _ => {}
+            }
+        }
+
+        // Infation
+
+        for i in 0..5 {
+            match i {
+                0..=1 => {
+                    let inflation = SqlInflation {
+                        id: i,
+                        sql_asset_id: 0,
+                        outpoint_txid: match i {
+                            0 => Some(
+                                "eca6748a4a7cca292aefee3ec8df5af02de80891adc58ee2f455c6a00a723cfe"
+                                    .to_string(),
+                            ),
+                            1 => None,
+                            _ => Some("Somethings wrong".to_string()),
+                        },
+                        outpoint_vout: match i {
+                            0 => Some(5),
+                            1 => None,
+                            _ => None,
+                        },
+                        accounting_amount: 3000,
+                    };
+                    diesel::insert_into(sql_inflation_table)
+                        .values(inflation)
+                        .execute(&conn)
+                        .unwrap();
+                }
+
+                2..=3 => {
+                    let inflation = SqlInflation {
+                        id: i,
+                        sql_asset_id: 1,
+                        outpoint_txid: match i {
+                            2 => Some(
+                                "a2b8d4924f03d7ce008c95c8f9c0365944c12d7898cc0453be5010176117c3da"
+                                    .to_string(),
+                            ),
+                            3 => None,
+                            _ => Some("Somethings wrong".to_string()),
+                        },
+                        outpoint_vout: match i {
+                            2 => Some(5),
+                            3 => None,
+                            _ => None,
+                        },
+                        accounting_amount: 3000,
+                    };
+                    diesel::insert_into(sql_inflation_table)
+                        .values(inflation)
+                        .execute(&conn)
+                        .unwrap();
+                }
+
+                _ => {}
+            }
+        }
+
+        // Allocation outpoints
+        for i in 0..5 {
+            match i {
+                0..=1 => {
+                    let allocation_utxo = SqlAllocationUtxo {
+                        id: i,
+                        sql_asset_id: 0,
+                        txid: "fc63f797af718cc5a11988f69507701d5fe84e58cdd900e1b02856c0ea5a058a"
+                            .to_string(),
+                        vout: i * 2,
+                    };
+
+                    diesel::insert_into(sql_allocation_utxo_table)
+                        .values(allocation_utxo)
+                        .execute(&conn)
+                        .unwrap();
+                }
+                2..=3 => {
+                    let allocation_utxo = SqlAllocationUtxo {
+                        id: i,
+                        sql_asset_id: 1,
+                        txid: "fc63f797af718cc5a11988f69507701d5fe84e58cdd900e1b02856c0ea5a058a"
+                            .to_string(),
+                        vout: i * 2,
+                    };
+
+                    diesel::insert_into(sql_allocation_utxo_table)
+                        .values(allocation_utxo)
+                        .execute(&conn)
+                        .unwrap();
+                }
+                _ => {}
+            }
+        }
+
+        // Allocations
+        for i in 0..8 {
+            match i {
+                0..=1 => {
+                    let allocation = SqlAllocation {
+                        id: i,
+                        sql_allocation_utxo_id: 0,
+                        node_id: "3854d4e041fc301afee0c91ac06451ac7c0a0b37d965172f693d421769a27e94"
+                            .to_string(),
+                        assignment_index: i * 3 - 1,
+                        amount: 50000,
+                        blinding:
+                            "7c62d1e24a6e99e30743ff94e5d3f783efc1ab8016d342558802c7f56e06ac15"
+                                .to_string(),
+                    };
+
+                    diesel::insert_into(sql_allocation_table)
+                        .values(allocation)
+                        .execute(&conn)
+                        .unwrap();
+                }
+
+                2..=3 => {
+                    let allocation = SqlAllocation {
+                        id: i,
+                        sql_allocation_utxo_id: 1,
+                        node_id: "3854d4e041fc301afee0c91ac06451ac7c0a0b37d965172f693d421769a27e94"
+                            .to_string(),
+                        assignment_index: i * 3 - 1,
+                        amount: 50000,
+                        blinding:
+                            "7c62d1e24a6e99e30743ff94e5d3f783efc1ab8016d342558802c7f56e06ac15"
+                                .to_string(),
+                    };
+
+                    diesel::insert_into(sql_allocation_table)
+                        .values(allocation)
+                        .execute(&conn)
+                        .unwrap();
+                }
+
+                4..=5 => {
+                    let allocation = SqlAllocation {
+                        id: i,
+                        sql_allocation_utxo_id: 2,
+                        node_id: "3854d4e041fc301afee0c91ac06451ac7c0a0b37d965172f693d421769a27e94"
+                            .to_string(),
+                        assignment_index: i * 3 - 1,
+                        amount: 50000,
+                        blinding:
+                            "7c62d1e24a6e99e30743ff94e5d3f783efc1ab8016d342558802c7f56e06ac15"
+                                .to_string(),
+                    };
+
+                    diesel::insert_into(sql_allocation_table)
+                        .values(allocation)
+                        .execute(&conn)
+                        .unwrap();
+                }
+
+                6..=7 => {
+                    let allocation = SqlAllocation {
+                        id: i,
+                        sql_allocation_utxo_id: 3,
+                        node_id: "3854d4e041fc301afee0c91ac06451ac7c0a0b37d965172f693d421769a27e94"
+                            .to_string(),
+                        assignment_index: i * 3 - 1,
+                        amount: 50000,
+                        blinding:
+                            "7c62d1e24a6e99e30743ff94e5d3f783efc1ab8016d342558802c7f56e06ac15"
+                                .to_string(),
+                    };
+
+                    diesel::insert_into(sql_allocation_table)
+                        .values(allocation)
+                        .execute(&conn)
+                        .unwrap();
+                }
+
+                _ => {}
+            }
+        }
+
+        println!("Tables created");
+    }
+
+    #[test]
+    //#[ignore]
+    fn test_asset_cache() {
+        let database_url = env::var("DATABASE_URL")
+            .expect("Environment Variable 'DATABASE_URL' must be set to run this test");
+
+        let filepath = PathBuf::from(&database_url[..]);
+        let config = SqlCacheConfig {
+            data_dir: filepath,
+            data_format: DataFormat::Sqlite,
+        };
+
+        let mut cache = SqlCache::new(&config).unwrap();
+
+        // Test fetching all assets
+        let assets = cache.assets().unwrap();
+
+        assert_eq!(assets.len(), 2);
+
+        // Test fetching single assets
+        let asset = cache
+            .asset(
+                ContractId::from_hex(
+                    "7ce3b67036e32628fe5351f23d57186181dba3103b7e0a5d55ed511446f5a6a9",
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(asset.name(), &String::from("Ethereum"));
+        assert_eq!(
+            asset.description().clone().unwrap(),
+            String::from("I am Vitalik")
+        );
+
+        let asset = cache
+            .asset(
+                ContractId::from_hex(
+                    "5bb162c7c84fa69bd263a12b277b82155787a03537691619fed731432f6855dc",
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(asset.name(), &String::from("Bitcoin"));
+        assert_eq!(
+            asset.description().clone().unwrap(),
+            String::from("I am satoshi")
+        );
+
+        // Test checking existance of asset
+        assert!(cache
+            .has_asset(
+                ContractId::from_hex(
+                    "7ce3b67036e32628fe5351f23d57186181dba3103b7e0a5d55ed511446f5a6a9"
+                )
+                .unwrap()
+            )
+            .unwrap());
+        assert!(cache
+            .has_asset(
+                ContractId::from_hex(
+                    "5bb162c7c84fa69bd263a12b277b82155787a03537691619fed731432f6855dc"
+                )
+                .unwrap()
+            )
+            .unwrap());
+
+        // Test Adding Asset
+        // Copy the first asset entry and change contract id
+        let mut first_sql_asset = sql_asset_table
+            .load::<SqlAsset>(&cache.connection)
+            .unwrap()
+            .first()
+            .cloned()
+            .unwrap();
+
+        first_sql_asset.contract_id =
+            String::from("9b9dc7065be8fe0a965f42dc4d64bd1e15aa56cf05d3c72fc472c55490936bb3");
+
+        let new_asset = Asset::from_sql_asset(&first_sql_asset, &cache.connection).unwrap();
+
+        assert!(cache.add_asset(new_asset).is_ok());
+
+        let mut new_cache = SqlCache::new(&config).unwrap();
+
+        assert_eq!(new_cache.assets().unwrap().len(), 3);
+        assert_eq!(
+            new_cache
+                .asset(
+                    ContractId::from_hex(
+                        "9b9dc7065be8fe0a965f42dc4d64bd1e15aa56cf05d3c72fc472c55490936bb3"
+                    )
+                    .unwrap()
+                )
+                .unwrap()
+                .name(),
+            &String::from("Bitcoin")
+        );
+
+        // Test removing asset the new added asset
+        assert!(new_cache
+            .remove_asset(
+                ContractId::from_hex(
+                    "9b9dc7065be8fe0a965f42dc4d64bd1e15aa56cf05d3c72fc472c55490936bb3"
+                )
+                .unwrap()
+            )
+            .unwrap());
+
+        let newer_cache = SqlCache::new(&config).unwrap();
+
+        assert_eq!(newer_cache.assets().unwrap().len(), 2);
+    }
+}

--- a/src/contracts/fungible/cache/sql.rs
+++ b/src/contracts/fungible/cache/sql.rs
@@ -276,12 +276,12 @@ mod test {
     use std::env;
 
     // The following tests are ignored by default, because they will break
-    // Travis CI unless the build setup is updated (TODO). To run these tests, 
+    // Travis CI unless the build setup is updated (TODO). To run these tests,
     // 1. set an environment variable DATABASE_URL=~/.rgb.
     // 2. manually remove the ignore flag and run the rgb-node/test/test_db.sh.
-    
+
     #[test]
-    //#[ignore]
+    #[ignore]
     // Creates a sample table with sample asset data
     fn test_create_tables() {
         let database_url = env::var("DATABASE_URL")
@@ -582,7 +582,7 @@ mod test {
     }
 
     #[test]
-    //#[ignore]
+    #[ignore]
     fn test_asset_cache() {
         let database_url = env::var("DATABASE_URL")
             .expect("Environment Variable 'DATABASE_URL' must be set to run this test");

--- a/src/contracts/fungible/cache/sql.rs
+++ b/src/contracts/fungible/cache/sql.rs
@@ -29,7 +29,6 @@ use cache_schema::sql_issues::dsl::sql_issues as sql_issue_table;
 
 use crate::contracts::fungible::data::Asset;
 
-use crate::error::{BootstrapError, ServiceErrorDomain};
 use std::path::PathBuf;
 
 use super::cache::{Cache, CacheError};
@@ -59,18 +58,6 @@ pub enum SqlCacheError {
 
     #[from(std::option::NoneError)]
     NotFound,
-}
-
-impl From<SqlCacheError> for ServiceErrorDomain {
-    fn from(_: SqlCacheError) -> Self {
-        ServiceErrorDomain::Cache
-    }
-}
-
-impl From<SqlCacheError> for BootstrapError {
-    fn from(_: SqlCacheError) -> Self {
-        BootstrapError::CacheError
-    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Display)]

--- a/src/contracts/fungible/data/asset.rs
+++ b/src/contracts/fungible/data/asset.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use crate::contracts::fungible::cache::models::{
     read_allocations, read_inflation, SqlAllocation, SqlAllocationUtxo, SqlAsset, SqlIssue,
 };
-use crate::contracts::fungible::cache::sql::SqlCacheError;
+use crate::contracts::fungible::cache::SqlCacheError;
 use lnpbp::bitcoin;
 use lnpbp::bitcoin::hashes::Hash;
 use lnpbp::bitcoin::{OutPoint, Txid};

--- a/src/contracts/fungible/data/asset.rs
+++ b/src/contracts/fungible/data/asset.rs
@@ -145,9 +145,8 @@ pub struct Asset {
 }
 
 impl Asset {
-
     /// Create an Asset structure from an sqlite asset table entry.
-    /// This fetches all the other tables for entries associated with the given asset 
+    /// This fetches all the other tables for entries associated with the given asset
     /// and recreates the full Asset structure. This should be used while reading Asset data from
     /// database table.
     pub fn from_sql_asset(
@@ -192,8 +191,7 @@ pub struct Allocation {
 }
 
 impl Allocation {
-
-    /// Create an Allocation structure by reading the 
+    /// Create an Allocation structure by reading the
     /// corresponding Allocation and AllocationUtxo table entries.
     pub fn from_sql_allocation(
         table_value: &SqlAllocation,
@@ -247,7 +245,7 @@ impl Supply {
 
     /// Supply do not have a corresponding table in the database.
     /// The concerned values are written in the Asset table itself.
-    /// This reads up an asset table entry and create the corresponding 
+    /// This reads up an asset table entry and create the corresponding
     /// supply structure.
     pub fn from_sql_asset(table_value: &SqlAsset) -> Self {
         Self {

--- a/src/contracts/fungible/data/asset.rs
+++ b/src/contracts/fungible/data/asset.rs
@@ -14,16 +14,26 @@
 use core::convert::{TryFrom, TryInto};
 use core::ops::{Add, AddAssign};
 use core::option::NoneError;
+use diesel::prelude::*;
 use std::collections::BTreeMap;
 
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
+use crate::contracts::fungible::cache::models::{
+    read_allocations, read_chain_from_table, read_inflation, SqlAllocation, SqlAllocationUtxo,
+    SqlAsset, SqlIssue,
+};
+use crate::contracts::fungible::cache::sql::SqlCacheError;
 use lnpbp::bitcoin;
 use lnpbp::bitcoin::hashes::Hash;
+use lnpbp::bitcoin::{OutPoint, Txid};
+use lnpbp::bitcoin_hashes::hex::FromHex;
 use lnpbp::bp;
 use lnpbp::rgb::prelude::*;
 use lnpbp::rgb::seal::WitnessVoutError;
+use lnpbp::secp256k1zkp::key::SecretKey;
+use lnpbp::secp256k1zkp::Secp256k1;
 
 use super::schema::{self, FieldType, OwnedRightsType};
 use crate::error::ServiceErrorDomain;
@@ -134,6 +144,40 @@ pub struct Asset {
     known_allocations: BTreeMap<bitcoin::OutPoint, Vec<Allocation>>,
 }
 
+impl Asset {
+
+    /// Create an Asset structure from an sqlite asset table entry.
+    /// This fetches all the other tables for entries associated with the given asset 
+    /// and recreates the full Asset structure. This should be used while reading Asset data from
+    /// database table.
+    pub fn from_sql_asset(
+        table_value: &SqlAsset,
+        connection: &SqliteConnection,
+    ) -> Result<Self, SqlCacheError> {
+        let (known_inflation, unknown_inflation) = read_inflation(table_value, connection).unwrap();
+
+        Ok(Self {
+            id: ContractId::from_hex(&table_value.contract_id[..]).unwrap(),
+            ticker: table_value.ticker.clone(),
+            name: table_value.asset_name.clone(),
+            description: table_value.asset_description.clone(),
+            supply: Supply::from_sql_asset(table_value),
+            chain: read_chain_from_table(table_value.chain.clone()).unwrap(),
+            fractional_bits: table_value.fractional_bits[0],
+            date: table_value.asset_date,
+            known_issues: SqlIssue::belonging_to(table_value)
+                .load::<SqlIssue>(connection)
+                .unwrap()
+                .into_iter()
+                .map(|issue| Issue::from_sql_issue(issue, table_value.fractional_bits[0]).unwrap())
+                .collect(),
+            known_inflation: known_inflation,
+            unknown_inflation: unknown_inflation,
+            known_allocations: read_allocations(table_value, connection).unwrap(),
+        })
+    }
+}
+
 #[derive(Clone, Getters, Serialize, Deserialize, PartialEq, Debug, Display)]
 #[display(Debug)]
 pub struct Allocation {
@@ -145,6 +189,33 @@ pub struct Allocation {
     /// `Asset::known_allocations`
     outpoint: bitcoin::OutPoint,
     value: value::Revealed,
+}
+
+impl Allocation {
+
+    /// Create an Allocation structure by reading the 
+    /// corresponding Allocation and AllocationUtxo table entries.
+    pub fn from_sql_allocation(
+        table_value: &SqlAllocation,
+        outpoint: &SqlAllocationUtxo,
+    ) -> Result<Self, SqlCacheError> {
+        Ok(Self {
+            node_id: NodeId::from_hex(&table_value.node_id[..]).unwrap(),
+            index: table_value.assignment_index as u16,
+            outpoint: OutPoint {
+                txid: Txid::from_hex(&outpoint.txid[..]).unwrap(),
+                vout: outpoint.vout as u32,
+            },
+            value: value::Revealed {
+                value: table_value.amount as AtomicValue,
+                blinding: SecretKey::from_slice(
+                    &Secp256k1::new(),
+                    &Vec::<u8>::from_hex(&table_value.blinding[..]).unwrap()[..],
+                )
+                .unwrap(),
+            },
+        })
+    }
 }
 
 #[derive(
@@ -173,6 +244,24 @@ impl Supply {
             None
         }
     }
+
+    /// Supply do not have a corresponding table in the database.
+    /// The concerned values are written in the Asset table itself.
+    /// This reads up an asset table entry and create the corresponding 
+    /// supply structure.
+    pub fn from_sql_asset(table_value: &SqlAsset) -> Self {
+        Self {
+            known_circulating: AccountingAmount::from_fractioned_accounting_value(
+                table_value.fractional_bits[0],
+                table_value.known_circulating_supply.clone() as AccountingValue,
+            ),
+            is_issued_known: table_value.is_issued_known.clone(),
+            max_cap: AccountingAmount::from_fractioned_accounting_value(
+                table_value.fractional_bits[0],
+                table_value.max_cap.clone() as AccountingValue,
+            ),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Getters, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
@@ -199,6 +288,29 @@ impl Issue {
 
     pub fn is_secondary(&self) -> bool {
         self.origin.is_some()
+    }
+
+    /// Create an Issue structure from reading the corresponding
+    /// Issue table entry in the database.
+    pub fn from_sql_issue(
+        table_value: SqlIssue,
+        fraction_bits: u8,
+    ) -> Result<Issue, SqlCacheError> {
+        Ok(Issue {
+            id: NodeId::from_hex(&table_value.node_id[..]).unwrap(),
+            asset_id: ContractId::from_hex(&table_value.contract_id[..]).unwrap(),
+            amount: AccountingAmount::from_fractioned_accounting_value(
+                fraction_bits,
+                table_value.amount.clone() as AccountingValue,
+            ),
+            origin: match (table_value.origin_txid, table_value.origin_vout) {
+                (Some(txid), Some(vout)) => Some(OutPoint {
+                    txid: Txid::from_hex(&txid[..]).unwrap(),
+                    vout: vout as u32,
+                }),
+                _ => None,
+            },
+        })
     }
 }
 

--- a/src/contracts/fungible/mod.rs
+++ b/src/contracts/fungible/mod.rs
@@ -26,6 +26,6 @@ pub use data::{
 pub use config::{Config, Opts};
 pub use runtime::{main_with_config, Runtime};
 
-pub use cache::CacheError;
+pub use cache::{CacheError, FileCacheError, SqlCacheError};
 pub use processor::IssueStructure;
 pub(self) use processor::Processor;

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,8 @@ pub enum BootstrapError {
 
     StorageError,
 
+    #[from(crate::contracts::fungible::FileCacheError)]
+    #[from(crate::contracts::fungible::SqlCacheError)]
     CacheError,
 
     Other,
@@ -134,6 +136,8 @@ pub enum ServiceErrorDomain {
     Stash,
     Storage(String),
     Index,
+    #[from(crate::contracts::fungible::FileCacheError)]
+    #[from(crate::contracts::fungible::SqlCacheError)]
     Cache,
     Multithreading,
     P2pwire,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,6 @@ pub enum DataFormat {
     /// Strict encoding
     #[display("strict-encode")]
     StrictEncode,
-
-    /// Sqlite Database
-    #[display("sqlite")]
-    Sqlite,
 }
 impl_enum_strict_encoding!(DataFormat);
 
@@ -87,7 +83,6 @@ impl DataFormat {
             DataFormat::Json => "json",
             DataFormat::Toml => "toml",
             DataFormat::StrictEncode => "se",
-            DataFormat::Sqlite => "db",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ pub extern crate lnpbp;
 #[macro_use]
 pub extern crate lnpbp_derive;
 
+#[macro_use]
+pub extern crate diesel;
+
 pub mod api;
 pub mod cli;
 pub mod constants;
@@ -70,6 +73,10 @@ pub enum DataFormat {
     /// Strict encoding
     #[display("strict-encode")]
     StrictEncode,
+
+    /// Sqlite Database
+    #[display("sqlite")]
+    Sqlite,
 }
 impl_enum_strict_encoding!(DataFormat);
 
@@ -80,6 +87,7 @@ impl DataFormat {
             DataFormat::Json => "json",
             DataFormat::Toml => "toml",
             DataFormat::StrictEncode => "se",
+            DataFormat::Sqlite => "db",
         }
     }
 }

--- a/test/test_db.sh
+++ b/test/test_db.sh
@@ -7,6 +7,6 @@ diesel migration run --database-url $DATABASE_URL/assets/assets.db --config-file
 
 cd ../..
 
-cargo test create_tables
+cargo test test_create_tables
 
 cargo test test_asset_cache

--- a/test/test_db.sh
+++ b/test/test_db.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-rm -f ~/.rgb/assets.db
+rm -f $DATABASE_URL/assets/assets.db
 
 cd db/cache/
-diesel database setup --database-url $DATABASE_URL/assets.db --config-file ./diesel.toml
-diesel migration run --database-url $DATABASE_URL/assets.db --config-file ./diesel.toml
+diesel database setup --database-url $DATABASE_URL/assets/assets.db --config-file ./diesel.toml
+diesel migration run --database-url $DATABASE_URL/assets/assets.db --config-file ./diesel.toml
 
 cd ../..
 

--- a/test/test_db.sh
+++ b/test/test_db.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+rm -f ~/.rgb/assets.db
+
+cd db/cache/
+diesel database setup --database-url $DATABASE_URL/assets.db --config-file ./diesel.toml
+diesel migration run --database-url $DATABASE_URL/assets.db --config-file ./diesel.toml
+
+cd ../..
+
+cargo test create_tables
+
+cargo test test_asset_cache


### PR DESCRIPTION
This closes [Issue#58](https://github.com/LNP-BP/rgb-node/issues/58). This is WIP and intended for initial review and suggestions for possible modifications.

**Note:** 
Two test cases are added to test the working of an asset db. These tests are ignored by default as they will break travis build.
To test the DB do the followings: 

- Install diesel-cli by running `cargo install diesel-cli`
- Setup an environment variable pointing at the rgb datadir `export DATABASE_URL=~/.rgb`
- Manually remove `#[ignore]` flag from tests in `src/contract/fungible/cache/sql.rs`.
- run the testing script in `test/test_db.sh`.

This should run the tests, and if all goes well they should pass.

**Rough Edges**

- `Chain` variants are not fully covered. The database only supports `MainNet` and `Testnet3` for now as they can be encoded via text. The rest of the variants need more expressive table types or probably new tables to handle them. Suggestions are welcome. At least if we can do `Regtest` it will be usable for experimenting with real rgb-node.

**Possible Improvements**  
Once this PR gets finalized it would better to integrate Travis to run these tests. They have to be handled separately from regular tests as it involves running `diesel-cli` and setting up env variable. 