### PR TITLE
Cache API enhancement

### DIFF
--- a/src/contracts/fungible/cache/cache.rs
+++ b/src/contracts/fungible/cache/cache.rs
@@ -31,13 +31,13 @@ pub trait Cache {
     fn remove_asset(&mut self, id: ContractId) -> Result<bool, Self::Error>;
 
     /// Returns the map of Utxo-Allocation_amount for a given asset
-    fn utxo_allocation_map(
+    fn asset_allocations(
         &self,
         contract_id: ContractId,
     ) -> Result<HashMap<bitcoin::OutPoint, Vec<AtomicValue>>, Self::Error>;
 
     /// Returns the map of Asset-Allocation_amount for a given Outpoint
-    fn asset_allocation_map(
+    fn output_assets(
         &self,
         utxo: &bitcoin::OutPoint,
     ) -> Result<HashMap<ContractId, Vec<AtomicValue>>, CacheError>;

--- a/src/contracts/fungible/cache/cache.rs
+++ b/src/contracts/fungible/cache/cache.rs
@@ -13,7 +13,7 @@
 
 use lnpbp::bitcoin;
 use lnpbp::rgb::prelude::*;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 use super::sql::SqlCacheError;
 use super::FileCacheError;
@@ -30,17 +30,17 @@ pub trait Cache {
     fn add_asset(&mut self, asset: Asset) -> Result<bool, Self::Error>;
     fn remove_asset(&mut self, id: ContractId) -> Result<bool, Self::Error>;
 
-    /// Return the map of Utxo-Allocation_amount for a given asset
+    /// Returns the map of Utxo-Allocation_amount for a given asset
     fn utxo_allocation_map(
         &self,
         contract_id: ContractId,
-    ) -> Result<BTreeMap<bitcoin::OutPoint, AtomicValue>, Self::Error>;
+    ) -> Result<HashMap<bitcoin::OutPoint, Vec<AtomicValue>>, Self::Error>;
 
     /// Returns the map of Asset-Allocation_amount for a given Outpoint
     fn asset_allocation_map(
         &self,
         utxo: &bitcoin::OutPoint,
-    ) -> Result<BTreeMap<String, u32>, CacheError>;
+    ) -> Result<HashMap<ContractId, Vec<AtomicValue>>, CacheError>;
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, Error)]

--- a/src/contracts/fungible/cache/cache.rs
+++ b/src/contracts/fungible/cache/cache.rs
@@ -11,7 +11,9 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
+use lnpbp::bitcoin;
 use lnpbp::rgb::prelude::*;
+use std::collections::BTreeMap;
 
 use super::sql::SqlCacheError;
 use super::FileCacheError;
@@ -27,6 +29,18 @@ pub trait Cache {
     fn has_asset(&self, id: ContractId) -> Result<bool, Self::Error>;
     fn add_asset(&mut self, asset: Asset) -> Result<bool, Self::Error>;
     fn remove_asset(&mut self, id: ContractId) -> Result<bool, Self::Error>;
+
+    /// Return the map of Utxo-Allocation_amount for a given asset
+    fn utxo_allocation_map(
+        &self,
+        contract_id: ContractId,
+    ) -> Result<BTreeMap<bitcoin::OutPoint, AtomicValue>, Self::Error>;
+
+    /// Returns the map of Asset-Allocation_amount for a given Outpoint
+    fn asset_allocation_map(
+        &self,
+        utxo: &bitcoin::OutPoint,
+    ) -> Result<BTreeMap<String, u32>, CacheError>;
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Display, Error)]

--- a/test/test_db.sh
+++ b/test/test_db.sh
@@ -7,6 +7,10 @@ diesel migration run --database-url $DATABASE_URL/assets/assets.db --config-file
 
 cd ../..
 
-cargo test test_create_tables
+cargo test test_sqlite_create_tables
 
-cargo test test_asset_cache
+cargo test test_sqlite_asset_cache
+
+cargo test test_sqlite_utxo_allocation
+
+cargo test test_sqlite_asset_allocation

--- a/test/test_db.sh
+++ b/test/test_db.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-rm -f $DATABASE_URL/assets/assets.db
+rm -f $DATABASE_URL/assets/assets*
 
 cd db/cache/
 diesel database setup --database-url $DATABASE_URL/assets/assets.db --config-file ./diesel.toml
@@ -11,6 +11,6 @@ cargo test test_sqlite_create_tables
 
 cargo test test_sqlite_asset_cache
 
-cargo test test_sqlite_utxo_allocation
+cargo test test_sqlite_mappings
 
-cargo test test_sqlite_asset_allocation
+cargo test test_filecache_mappings


### PR DESCRIPTION
This adds convenience function to `Cache` to easily retrieve relevant asset information. This closes [Issue84](https://github.com/LNP-BP/rgb-node/issues/84).

Note:

- Asset listing function for cache is not separately implemented as there is already `assets()` API for `Cache` which does the same.

- `utxo_allocation_map(contract_id)` gives a map of `Map[Outpoint, Amount]` for a given asset identified by `contract_id`.

- `asset_allocation_map(utxo)` gives a map of `Map[Asset_name, Amount]` for a given `utxo`. There can be multiple `Asset` tied to a single `utxo`. Currently, the map only returns the asset name. This can be changed to any required field as needed.

- `asset_allocation_map(utxo)` is not implemented for `FileCache` as I didn't have enough time to play around with `FileCache`, this is marked as a `ToDo`.

- Test table for SQLite cache is updated to simulate many to many Asset-Utxo mapping. Test cases for the above two API are added. 
