### PR TITLE
Expose rgb::fungible::data::invoice::Error as InvoiceError

### DIFF
--- a/src/contracts/fungible/data/mod.rs
+++ b/src/contracts/fungible/data/mod.rs
@@ -19,6 +19,8 @@ pub mod schema;
 pub use asset::{
     AccountingAmount, AccountingValue, Allocation, Asset, Issue, Supply,
 };
-pub use invoice::{Invoice, Outpoint, OutpointDescriptor};
+pub use invoice::{
+    Error as InvoiceError, Invoice, Outpoint, OutpointDescriptor,
+};
 pub use outcoins::{Outcoincealed, Outcoins};
 pub use schema::Error;

--- a/src/contracts/fungible/mod.rs
+++ b/src/contracts/fungible/mod.rs
@@ -19,8 +19,8 @@ mod runtime;
 pub(self) mod cache;
 
 pub use data::{
-    schema, AccountingAmount, Allocation, Asset, Error, Invoice, Issue,
-    Outcoincealed, Outcoins, Outpoint, OutpointDescriptor, Supply,
+    schema, AccountingAmount, Allocation, Asset, Error, Invoice, InvoiceError,
+    Issue, Outcoincealed, Outcoins, Outpoint, OutpointDescriptor, Supply,
 };
 
 pub use config::{Config, Opts};


### PR DESCRIPTION
this PR exposes `rgb::fungible::data::invoice::Error` as `InvoiceError`.
this is required by `rgb-sdk` in order to convert the error in a common error type (as discussed in LNP-BP/rgb-sdk#12).