### PR TITLE
Bug Fix #Issue107

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ client = ["zmq", "lnpbp_services/client", "lnpbp/keygen", "async-trait",
           "regex", "tokio", "electrum-client", "base64",
           "url", "lnpbp/url", "log", "env_logger",
           # TODO: Femove the following after feature gates debugging:
-          "clap"]
+          "clap", "serde"]
 # Embedded is an app that contains ndoe in itself and that talks to it through
 # integration layer
 embedded = ["client", "node", "lnpbp_services/embedded"]


### PR DESCRIPTION
Fixes #107 

There was a dependency satisfaction issue in the `default` feature of the crate, because `client` did not have `serde`. This wasn't caught by the CI tests, because it was building with `--all-features` flag. But the default build was failing all the time. 

I have put `serde` inside `client` to make `deafult` pass, for now. Will update if thats not appropriate.

Suggestion: For some weird reason it seems `--all-features` doesn't build `deafult`. Lets put a `default` build also in CI so such divergence doesn't happen in the future. 