### PR TITLE
Fix ignored config params

### DIFF
--- a/src/contracts/fungible/config.rs
+++ b/src/contracts/fungible/config.rs
@@ -54,7 +54,7 @@ pub struct Opts {
     )]
     pub rpc_endpoint: String,
 
-    /// ZMQ socket address string for PUB/SUb API
+    /// ZMQ socket address string for PUB/SUB API
     #[clap(
         long = "pub",
         default_value = FUNGIBLED_PUB_ENDPOINT,
@@ -152,6 +152,7 @@ impl Config {
         T::Err: Display,
     {
         param
+            .replace("{id}", "default")
             .replace("{network}", &self.network.to_string())
             .replace("{data_dir}", self.data_dir.to_str().unwrap())
             .parse()

--- a/src/i9n/config.rs
+++ b/src/i9n/config.rs
@@ -14,7 +14,6 @@
 use std::collections::HashMap;
 
 use lnpbp::bp;
-use lnpbp::lnp::transport::zmqsocket::ZmqSocketAddr;
 
 use crate::constants::*;
 use crate::rgbd::ContractName;
@@ -22,8 +21,8 @@ use crate::rgbd::ContractName;
 #[derive(Clone, PartialEq, Eq, Debug, Display)]
 #[display(Debug)]
 pub struct Config {
-    pub stash_endpoint: ZmqSocketAddr,
-    pub contract_endpoints: HashMap<ContractName, ZmqSocketAddr>,
+    pub stash_rpc_endpoint: String,
+    pub contract_endpoints: HashMap<ContractName, String>,
     pub network: bp::Chain,
     pub threaded: bool,
     pub data_dir: String,
@@ -32,7 +31,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            stash_endpoint: STASHD_RPC_ENDPOINT
+            stash_rpc_endpoint: STASHD_RPC_ENDPOINT
                 .parse()
                 .expect("Error in STASHD_RPC_ENDPOINT constant value"),
             contract_endpoints: map! {

--- a/src/i9n/config.rs
+++ b/src/i9n/config.rs
@@ -22,6 +22,8 @@ use crate::rgbd::ContractName;
 #[display(Debug)]
 pub struct Config {
     pub stash_rpc_endpoint: String,
+    pub stash_pub_endpoint: String,
+    pub fungible_pub_endpoint: String,
     pub contract_endpoints: HashMap<ContractName, String>,
     pub network: bp::Chain,
     pub threaded: bool,
@@ -34,6 +36,12 @@ impl Default for Config {
             stash_rpc_endpoint: STASHD_RPC_ENDPOINT
                 .parse()
                 .expect("Error in STASHD_RPC_ENDPOINT constant value"),
+            stash_pub_endpoint: STASHD_PUB_ENDPOINT
+                .parse()
+                .expect("Error in STASHD_PUB_ENDPOINT constant value"),
+            fungible_pub_endpoint: FUNGIBLED_PUB_ENDPOINT
+                .parse()
+                .expect("Error in FUNGIBLED_PUB_ENDPOINT constant value"),
             contract_endpoints: map! {
                 ContractName::Fungible
                     => FUNGIBLED_RPC_ENDPOINT

--- a/src/i9n/runtime.rs
+++ b/src/i9n/runtime.rs
@@ -50,6 +50,8 @@ impl Runtime {
                     .unwrap_or(&FUNGIBLED_RPC_ENDPOINT.to_string())
                     .clone(),
                 stash_rpc_endpoint: config.stash_rpc_endpoint.clone(),
+                stash_pub_endpoint: config.stash_pub_endpoint.clone(),
+                fungible_pub_endpoint: config.fungible_pub_endpoint.clone(),
                 network: config.network.clone(),
                 threaded: true,
                 ..rgbd::Opts::default()

--- a/src/i9n/runtime.rs
+++ b/src/i9n/runtime.rs
@@ -21,6 +21,7 @@ use lnpbp::lnp::{
 
 use super::Config;
 use crate::api::Reply;
+use crate::constants::FUNGIBLED_RPC_ENDPOINT;
 use crate::error::BootstrapError;
 use crate::rgbd::{self, ContractName};
 
@@ -46,7 +47,7 @@ impl Runtime {
                 fungible_rpc_endpoint: config
                     .contract_endpoints
                     .get(&ContractName::Fungible)
-                    .unwrap()
+                    .unwrap_or(&FUNGIBLED_RPC_ENDPOINT.to_string())
                     .clone(),
                 stash_rpc_endpoint: config.stash_rpc_endpoint.clone(),
                 network: config.network.clone(),

--- a/src/i9n/runtime.rs
+++ b/src/i9n/runtime.rs
@@ -21,7 +21,6 @@ use lnpbp::lnp::{
 
 use super::Config;
 use crate::api::Reply;
-use crate::constants::FUNGIBLED_RPC_ENDPOINT;
 use crate::error::BootstrapError;
 use crate::rgbd::{self, ContractName};
 
@@ -47,7 +46,9 @@ impl Runtime {
                 fungible_rpc_endpoint: config
                     .contract_endpoints
                     .get(&ContractName::Fungible)
-                    .unwrap_or(&FUNGIBLED_RPC_ENDPOINT.to_string())
+                    .ok_or(BootstrapError::ArgParseError(s!(
+                        "Fungible endpoint is unconfigured"
+                    )))?
                     .clone(),
                 stash_rpc_endpoint: config.stash_rpc_endpoint.clone(),
                 stash_pub_endpoint: config.stash_pub_endpoint.clone(),

--- a/src/rgbd/config.rs
+++ b/src/rgbd/config.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 use serde::Deserialize;
 
 use crate::constants::*;
+use crate::DataFormat;
 
 #[derive(Clap)]
 #[clap(
@@ -43,6 +44,80 @@ pub struct Opts {
     #[clap(arg_enum, long = "contract", default_value = RGB_CONTRACTS, env = "RGB_CONTRACTS")]
     pub contracts: Vec<ContractName>,
 
+    /// ZMQ socket address string for REQ/REP API of fungibled
+    #[clap(
+        long = "fungible-rpc",
+        default_value = FUNGIBLED_RPC_ENDPOINT,
+        env = "RGB_FUNGIBLED_RPC"
+    )]
+    pub fungible_rpc_endpoint: String,
+
+    /// ZMQ socket address string for PUB/SUB API of fungibled
+    #[clap(
+        long = "fungible-pub",
+        default_value = FUNGIBLED_PUB_ENDPOINT,
+        env = "RGB_FUNGIBLED_PUB"
+    )]
+    pub fungible_pub_endpoint: String,
+
+    /// ZMQ socket address string for REQ/REP API of stashd
+    #[clap(
+        long = "stash-rpc",
+        default_value = STASHD_RPC_ENDPOINT,
+        env = "RGB_STASHD_RPC"
+    )]
+    pub stash_rpc_endpoint: String,
+
+    /// ZMQ socket address string for PUB/SUB API of stashd
+    #[clap(
+        long = "stash-pub",
+        default_value = STASHD_PUB_ENDPOINT,
+        env = "RGB_STASHD_PUB"
+    )]
+    pub stash_pub_endpoint: String,
+
+    /// Connection string to fungibled cache (exact format depends on used
+    /// storage engine)
+    #[clap(
+        short = 'c',
+        long = "cache",
+        default_value = FUNGIBLED_CACHE,
+        env = "RGB_FUNGIBLED_CACHE"
+    )]
+    pub cache: String,
+
+    /// Data format for fungibled cache storage (valid only if file storage is
+    /// used)
+    #[clap(short, long, default_value = "yaml", env = "RGB_FUNGIBLED_FORMAT")]
+    pub format: DataFormat,
+
+    /// Connection string to stashd stash (exact format depends on used storage
+    /// engine)
+    #[clap(
+        short,
+        long,
+        default_value = STASHD_STASH,
+        env = "RGB_STASHD_STASH"
+    )]
+    pub stash: String,
+
+    /// Connection string to indexing service
+    #[clap(
+        short,
+        long,
+        default_value = STASHD_INDEX,
+        env = "RGB_STASHD_INDEX"
+    )]
+    pub index: String,
+
+    /// LNP socket address string for P2P API of stashd
+    #[clap(
+        long = "bind",
+        default_value = STASHD_P2P_ENDPOINT,
+        env = "RGB_STASHD_BIND"
+    )]
+    pub p2p_endpoint: String,
+
     /// Run services as threads instead of daemons
     #[clap(short, long)]
     pub threaded: bool,
@@ -50,6 +125,14 @@ pub struct Opts {
     /// Bitcoin network to use
     #[clap(short, long, default_value = RGB_NETWORK, env = "RGB_NETWORK")]
     pub network: bp::Chain,
+
+    /// Electrum server to use to fecth Bitcoin transactions
+    #[clap(
+        long = "electrum",
+        default_value = DEFAULT_ELECTRUM_ENDPOINT,
+        env = "RGB_ELECTRUM_SERVER"
+    )]
+    pub electrum_server: String,
 }
 
 #[derive(Clap, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display)]
@@ -86,6 +169,16 @@ pub struct Config {
     pub contracts: Vec<ContractName>,
     pub network: bp::Chain,
     pub verbose: u8,
+    pub fungible_rpc_endpoint: String,
+    pub fungible_pub_endpoint: String,
+    pub stash_rpc_endpoint: String,
+    pub stash_pub_endpoint: String,
+    pub cache: String,
+    pub format: DataFormat,
+    pub stash: String,
+    pub index: String,
+    pub p2p_endpoint: String,
+    pub electrum_server: String,
 }
 
 impl From<Opts> for Config {
@@ -96,8 +189,17 @@ impl From<Opts> for Config {
             threaded: opts.threaded,
             network: opts.network,
             contracts: opts.contracts,
+            fungible_rpc_endpoint: opts.fungible_rpc_endpoint,
+            fungible_pub_endpoint: opts.fungible_pub_endpoint,
+            stash_rpc_endpoint: opts.stash_rpc_endpoint,
+            stash_pub_endpoint: opts.stash_pub_endpoint,
+            cache: opts.cache,
+            format: opts.format,
+            stash: opts.stash,
+            index: opts.index,
+            p2p_endpoint: opts.p2p_endpoint,
             verbose: opts.verbose,
-            ..Config::default()
+            electrum_server: opts.electrum_server,
         }
     }
 }
@@ -114,10 +216,54 @@ impl Default for Config {
             threaded: false,
             contracts: vec![ContractName::from_str(RGB_CONTRACTS, false)
                 .expect("Error in RGB_CONTRACTS constant value")],
+            fungible_rpc_endpoint: FUNGIBLED_RPC_ENDPOINT.to_string(),
+            fungible_pub_endpoint: FUNGIBLED_PUB_ENDPOINT.to_string(),
+            stash_rpc_endpoint: STASHD_RPC_ENDPOINT.to_string(),
+            stash_pub_endpoint: STASHD_PUB_ENDPOINT.to_string(),
+            cache: FUNGIBLED_CACHE.to_string(),
+            format: DataFormat::Yaml,
+            stash: STASHD_STASH.to_string(),
+            index: STASHD_INDEX.to_string(),
+            p2p_endpoint: STASHD_P2P_ENDPOINT.to_string(),
             network: RGB_NETWORK
                 .parse()
                 .expect("Error in RGB_NETWORK constant value"),
             verbose: 0,
+            electrum_server: DEFAULT_ELECTRUM_ENDPOINT
+                .parse()
+                .expect("Error in DEFAULT_ELECTRUM_ENDPOINT constant value"),
+        }
+    }
+}
+
+impl Default for Opts {
+    fn default() -> Self {
+        Self {
+            data_dir: RGB_DATA_DIR
+                .parse()
+                .expect("Error in RGB_DATA_DIR constant value"),
+            bin_dir: RGB_BIN_DIR
+                .parse()
+                .expect("Error in RGB_BIN_DIR constant value"),
+            threaded: false,
+            contracts: vec![ContractName::from_str(RGB_CONTRACTS, false)
+                .expect("Error in RGB_CONTRACTS constant value")],
+            fungible_rpc_endpoint: FUNGIBLED_RPC_ENDPOINT.to_string(),
+            fungible_pub_endpoint: FUNGIBLED_PUB_ENDPOINT.to_string(),
+            stash_rpc_endpoint: STASHD_RPC_ENDPOINT.to_string(),
+            stash_pub_endpoint: STASHD_PUB_ENDPOINT.to_string(),
+            cache: FUNGIBLED_CACHE.to_string(),
+            format: DataFormat::Yaml,
+            stash: STASHD_STASH.to_string(),
+            index: STASHD_INDEX.to_string(),
+            p2p_endpoint: STASHD_P2P_ENDPOINT.to_string(),
+            network: RGB_NETWORK
+                .parse()
+                .expect("Error in RGB_NETWORK constant value"),
+            verbose: 0,
+            electrum_server: DEFAULT_ELECTRUM_ENDPOINT
+                .parse()
+                .expect("Error in DEFAULT_ELECTRUM_ENDPOINT constant value"),
         }
     }
 }

--- a/src/stash/config.rs
+++ b/src/stash/config.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 
 use lnpbp::bp;
 use lnpbp::lnp::transport::zmqsocket::ZmqSocketAddr;
-use lnpbp::lnp::{LocalNode, PartialNodeAddr};
+use lnpbp::lnp::LocalNode;
 
 use crate::constants::*;
 
@@ -47,10 +47,10 @@ pub struct Opts {
     pub index: String,
 
     /// LNP socket address string for P2P API
-    #[clap(long = "bind", env = "RGB_STASHD_BIND")]
-    pub p2p_endpoint: Option<String>,
+    #[clap(long = "bind", default_value = STASHD_P2P_ENDPOINT, env = "RGB_STASHD_BIND")]
+    pub p2p_endpoint: String,
 
-    /// ZMQ socket address string for RPC API
+    /// ZMQ socket address string for REQ/REP API
     #[clap(
         long = "rpc",
         default_value = STASHD_RPC_ENDPOINT,
@@ -90,7 +90,7 @@ pub struct Config {
     pub data_dir: PathBuf,
     pub stash: String,
     pub index: String,
-    pub p2p_endpoint: Option<PartialNodeAddr>,
+    pub p2p_endpoint: String,
     pub rpc_endpoint: ZmqSocketAddr,
     pub pub_endpoint: ZmqSocketAddr,
     pub network: bp::Chain,
@@ -109,7 +109,7 @@ impl From<Opts> for Config {
         me.index = me.parse_param(opts.index);
         me.rpc_endpoint = me.parse_param(opts.rpc_endpoint);
         me.pub_endpoint = me.parse_param(opts.pub_endpoint);
-        me.p2p_endpoint = opts.p2p_endpoint.map(|ep| me.parse_param(ep));
+        me.p2p_endpoint = me.parse_param(opts.p2p_endpoint);
         me.electrum_server = me.parse_param(opts.electrum_server);
         me
     }
@@ -125,7 +125,7 @@ impl Default for Config {
                 .expect("Error in RGB_DATA_DIR constant value"),
             stash: STASHD_STASH.to_string(),
             index: STASHD_INDEX.to_string(),
-            p2p_endpoint: None,
+            p2p_endpoint: STASHD_P2P_ENDPOINT.to_string(),
             rpc_endpoint: STASHD_RPC_ENDPOINT
                 .parse()
                 .expect("Error in STASHD_RPC_ENDPOINT constant value"),


### PR DESCRIPTION
closes LNP-BP/rgb-sdk#19 and #102

the solution is not very elegant, but since @dr-orlovsky said:

> Shared parts can be moved into a separate shared config like I did in LNP Node, but this is not a big priority for now and will be done anyway when I will be refactoring RGB Node to the best practices I used in LNP Node (there is a lot of other stuff which can be improved/made more efficient in this regard)

I tried to avoid changing the existing structure as much as possible 