### PR TITLE
add (import|export)_asset and list_assets methods to i9n

### DIFF
--- a/src/contracts/fungible/data/asset.rs
+++ b/src/contracts/fungible/data/asset.rs
@@ -163,7 +163,7 @@ impl AddAssign for AccountingAmount {
 )]
 #[display(Debug)]
 pub struct Asset {
-    id: ContractId, // This is a unique primary key
+    pub id: ContractId, // This is a unique primary key
     ticker: String,
     name: String,
     description: Option<String>,

--- a/src/contracts/fungible/data/invoice.rs
+++ b/src/contracts/fungible/data/invoice.rs
@@ -52,12 +52,22 @@ pub enum OutpointDescriptor {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize,),
+    serde(crate = "serde_crate")
+)]
 pub enum Outpoint {
     BlindedUtxo(OutpointHash),
     Address(bitcoin::Address),
 }
 
 #[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize,),
+    serde(crate = "serde_crate")
+)]
 pub struct Invoice {
     pub contract_id: ContractId,
     pub outpoint: Outpoint,

--- a/src/contracts/fungible/data/outcoins.rs
+++ b/src/contracts/fungible/data/outcoins.rs
@@ -15,7 +15,9 @@ use core::str::FromStr;
 use regex::Regex;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter};
+use std::hash::{Hash, Hasher};
 
 use lnpbp::bitcoin::{OutPoint, Txid};
 use lnpbp::bp::blind::{OutpointHash, OutpointReveal};
@@ -173,5 +175,25 @@ impl FromStr for ConsealCoins {
         } else {
             Err(ParseError)
         }
+    }
+}
+
+impl Eq for OutpointCoins {}
+
+impl PartialOrd for OutpointCoins {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OutpointCoins {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.outpoint.cmp(&other.outpoint)
+    }
+}
+
+impl Hash for OutpointCoins {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.outpoint.hash(state);
     }
 }

--- a/src/contracts/fungible/runtime.rs
+++ b/src/contracts/fungible/runtime.rs
@@ -318,7 +318,7 @@ impl Runtime {
     ) -> Result<Reply, ServiceErrorDomain> {
         debug!("Got SYNC");
         let data = self.cacher.export(Some(data_format))?;
-        Ok(Reply::Sync(reply::SyncFormat(self.config.format, data)))
+        Ok(Reply::Sync(reply::SyncFormat(data_format, data)))
     }
 
     async fn rpc_assets(

--- a/src/i9n/fungible.rs
+++ b/src/i9n/fungible.rs
@@ -23,7 +23,9 @@ use lnpbp::bp;
 use lnpbp::bp::psbt::ProprietaryKeyMap;
 use lnpbp::lnp::presentation::Encode;
 use lnpbp::lnp::{Session, Unmarshall};
-use lnpbp::rgb::{AtomicValue, Consignment, ContractId, PSBT_OUT_PUBKEY};
+use lnpbp::rgb::{
+    AtomicValue, Consignment, ContractId, Genesis, PSBT_OUT_PUBKEY,
+};
 
 use super::{Error, Runtime};
 use crate::api::{
@@ -215,13 +217,44 @@ impl Runtime {
         }
     }
 
-    pub fn sync(
+    pub fn export_asset(
+        &mut self,
+        asset_id: ContractId,
+    ) -> Result<Genesis, Error> {
+        match &*self.command(Request::ExportAsset(asset_id))? {
+            Reply::Failure(failure) => Err(Error::Reply(failure.clone())),
+            Reply::Genesis(response) => {
+                println!("Export asset succeeded");
+
+                Ok(response.clone())
+            }
+            _ => Err(Error::UnexpectedResponse),
+        }
+    }
+
+    pub fn import_asset(&mut self, genesis: Genesis) -> Result<(), Error> {
+        match &*self.command(Request::ImportAsset(genesis))? {
+            Reply::Failure(failure) => Err(Error::Reply(failure.clone())),
+            Reply::Success => {
+                println!("Import asset succeeded");
+
+                Ok(())
+            }
+            _ => Err(Error::UnexpectedResponse),
+        }
+    }
+
+    pub fn list_assets(
         &mut self,
         data_format: DataFormat,
     ) -> Result<reply::SyncFormat, Error> {
         match &*self.command(Request::Sync(data_format))? {
-            Reply::Sync(data) => Ok(data.clone()),
-            Reply::Failure(failmsg) => Err(Error::Reply(failmsg.clone())),
+            Reply::Failure(failure) => Err(Error::Reply(failure.clone())),
+            Reply::Sync(response) => {
+                println!("List assets succeeded");
+
+                Ok(response.clone())
+            }
             _ => Err(Error::UnexpectedResponse),
         }
     }


### PR DESCRIPTION
this PR is in draft because I'm not sure that the commit `ContractId: 'id' field public` will be necessary for LNP-BP/rgb-sdk#31. so I would wait to merge this after being sure that we manage to receive the `ContractId` in a bech32 format

also, I figured out that the `list_assets` method was already there in the `i9n` module, it was named `sync` (I've renamed it assuming no one was using that, let me know if this assumption is wrong)

closes #117 